### PR TITLE
Hide server info and add security headers

### DIFF
--- a/rootfs/etc/nginx/conf.d/security.conf
+++ b/rootfs/etc/nginx/conf.d/security.conf
@@ -1,5 +1,5 @@
     # Hardening with security headers
     add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
-    add_header X-Frame-Options DENY;
+    add_header X-Frame-Options SAMEORIGIN;
     add_header X-Content-Type-Options nosniff;
     add_header X-XSS-Protection "1; mode=block";

--- a/rootfs/etc/nginx/conf.d/security.conf
+++ b/rootfs/etc/nginx/conf.d/security.conf
@@ -1,0 +1,5 @@
+    # Hardening with security headers
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+    add_header X-XSS-Protection "1; mode=block";

--- a/rootfs/etc/nginx/nginx.conf
+++ b/rootfs/etc/nginx/nginx.conf
@@ -95,10 +95,6 @@ http {
     proxy_hide_header X-Powered-By;
     fastcgi_hide_header X-Powered-By;
     server_tokens off;
-    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
-    add_header X-Frame-Options DENY;
-    add_header X-Content-Type-Options nosniff;
-    add_header X-XSS-Protection "1; mode=block";
 
     # Include other server configs
     include /etc/nginx/conf.d/*.conf;

--- a/rootfs/etc/nginx/nginx.conf
+++ b/rootfs/etc/nginx/nginx.conf
@@ -91,6 +91,15 @@ http {
         }
     }
 
+    # Hardening
+    proxy_hide_header X-Powered-By;
+    fastcgi_hide_header X-Powered-By;
+    server_tokens off;
+    add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload";
+    add_header X-Frame-Options DENY;
+    add_header X-Content-Type-Options nosniff;
+    add_header X-XSS-Protection "1; mode=block";
+
     # Include other server configs
     include /etc/nginx/conf.d/*.conf;
 

--- a/rootfs/etc/php8/conf.d/custom.ini
+++ b/rootfs/etc/php8/conf.d/custom.ini
@@ -1,6 +1,8 @@
 [Date]
 date.timezone="UTC"
 
+expose_php= Off
+
 allow_url_fopen = $allow_url_fopen
 allow_url_include= $allow_url_include
 display_errors= $display_errors


### PR DESCRIPTION
NGINX and PHP-FPM versions are currently exposed in HTTP headers which are considered not secure enough as exposed OS info. Also added HTTP response headers for higher security.

References:
https://kubernetes.github.io/ingress-nginx/deploy/hardening-guide/
https://www.upguard.com/blog/how-to-build-a-tough-nginx-server-in-15-steps
https://beaglesecurity.com/blog/article/nginx-server-security.html
https://stackoverflow.com/questions/962230/hide-x-powered-by-nginx