### PR TITLE
Added memcached functionality and enhanced NGINX config loading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN apk --no-cache add \
         php8-fpm \
         php8-opcache \
         php8-pecl-apcu \
+        php8-pecl-memcached \
         php8-mysqli \
         php8-pgsql \
         php8-json \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN apk --no-cache add \
         php8-opcache \
         php8-pecl-apcu \
         php8-pecl-memcached \
+        php8-pecl-redis \
         php8-mysqli \
         php8-pgsql \
         php8-json \

--- a/rootfs/etc/nginx/nginx.conf
+++ b/rootfs/etc/nginx/nginx.conf
@@ -70,6 +70,9 @@ http {
             include fastcgi_params;
         }
 
+        # Include other server configs
+        include /etc/nginx/conf.d/default/server/*.conf;
+
         location ~* \.(jpg|jpeg|gif|png|css|js|ico|xml)$ {
             expires 5d;
         }


### PR DESCRIPTION
As alpine-moodle will overwrite the NGINX conf provided by alpine-php-webserver, it seems better to only add the extra part from alpine-moodle to preserve the other settings. This should keep the file easy to maintain.

Also, for moodle to work in cluster mode, a shared cache store will be needed. So I added memcached PHP package as the most light weight one.

Updated: added also redis PHP package for more flexibility.