### PR TITLE
Fix unable to set zlib.output_compression of PHP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -89,4 +89,4 @@ ENV client_max_body_size=2M \
     memory_limit=128M \
     post_max_size=8M \
     upload_max_filesize=2M \
-    zlib.output_compression=On
+    zlib_output_compression=On

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ You can define the next environment variables to change values from NGINX and PH
 | PHP8   | memory_limit            | 128M    | Maximum amount of memory in bytes that a script is allowed to allocate. This helps prevent poorly written scripts for eating up all available memory on a server. Note that to have no memory limit, set this directive to -1.                         |
 | PHP8   | post_max_size           | 8M      | Max size of post data allowed. This setting also affects file upload. To upload large files, this value must be larger than upload_max_filesize. Generally speaking, memory_limit should be larger than post_max_size.                                 |
 | PHP8   | upload_max_filesize     | 2M      | Maximum size of an uploaded file.                                                                                                                                                                                                                      |
-| PHP8   | zlib.output_compression | On      | Whether to transparently compress pages. If this option is set to "On" in php.ini or the Apache configuration, pages are compressed if the browser sends an "Accept-Encoding: gzip" or "deflate" header.                                               |
+| PHP8   | zlib_output_compression | On      | Whether to transparently compress pages. If this option is set to "On" in php.ini or the Apache configuration, pages are compressed if the browser sends an "Accept-Encoding: gzip" or "deflate" header.                                               |
 
 _Note; Because `-v` requires an absolute path I've added `pwd` in the example to return the absolute path to the current directory_
 

--- a/rootfs/etc/php81/conf.d/custom.ini
+++ b/rootfs/etc/php81/conf.d/custom.ini
@@ -11,4 +11,4 @@ max_input_vars= $max_input_vars
 memory_limit= $memory_limit
 post_max_size= $post_max_size
 upload_max_filesize= $upload_max_filesize
-zlib.output_compression= $zlib.output_compression
+zlib.output_compression= $zlib_output_compression


### PR DESCRIPTION
Linux variables name could not contains "dot". The caused `zlib.output_compression` could not be set and always empty. Suggest to change the variable name to `zlib_output_compression` to fix the issue.

(Backport of https://github.com/jimsihk/alpine-php-nginx/pull/33)