### PR TITLE
Fix shutdown timeout invalid parameter

### DIFF
--- a/rootfs/bin/docker-entrypoint.sh
+++ b/rootfs/bin/docker-entrypoint.sh
@@ -17,7 +17,7 @@ shutdown() {
 
   # kill any other processes still running in the container
   for _pid  in $(ps -eo pid | grep -v PID  | tr -d ' ' | grep -v '^1$' | head -n -6); do
-    timeout -t 5 /bin/sh -c "kill $_pid && wait $_pid || kill -9 $_pid"
+    timeout 5 /bin/sh -c "kill $_pid && wait $_pid || kill -9 $_pid"
   done
   exit
 }


### PR DESCRIPTION
I observed that below error shown up when shutdown the container:

> shutting down container
> ok: down: cron: 1s, normally up
> ok: down: nginx: 0s, normally up
> [10-Mar-2024 07:11:40] NOTICE: Terminating ...
> [10-Mar-2024 07:11:40] NOTICE: exiting, bye-bye!
> ok: down: php: 1s, normally up
> timeout: unrecognized option: t
> BusyBox v1.36.1 (2023-11-07 18:53:09 UTC) multi-call binary.
>
> Usage: timeout [-s SIG] [-k KILL_SECS] SECS PROG ARGS
>
> Run PROG. Send SIG to it if it is not gone in SECS seconds.
> Default SIG: TERM.If it still exists in KILL_SECS seconds, send KILL.
> 

It seems that the timeout behaviour in alpine seems different from the official manual:
https://busybox.net/downloads/BusyBox.html
> timeout
> timeout [-t SECS] [-s SIG] PROG [ARGS]
> 
> Runs PROG. Sends SIG to it if it is not gone in SECS seconds. Defaults: SECS: 10, SIG: TERM.

Further research it seems to be a known issue (see https://github.com/vishnubob/wait-for-it/issues/5), so propose the fix on this.