### PR TITLE
Add pdo and pdo_mysql extensions to php

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN apk --no-cache add \
         php82-opcache \
         php82-openssl \
         php82-pecl-apcu \
+        php82-pdo \
+        php82-pdo_mysql \
         php82-pgsql \
         php82-phar \
         php82-session \


### PR DESCRIPTION
I have been using your fork for a while, but sometimes I miss your updates since I have been using your base and just adding the two extra php extensions I need.

It would be easier if this was just part of your docker image, if you care to oblige me.

Thanks,
Jeff