### PR TITLE
Cherry-pick: Fix chown command to use colon for user and group separation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,10 @@ RUN apk --no-cache add \
 # Remove default server definition
     && rm /etc/nginx/http.d/default.conf \
 # Make sure files/folders needed by the processes are accessable when they run under the nobody user
-    && chown -R nobody:nobody /var/www/html /run /var/lib/nginx /var/log/nginx
+    && chown -R nobody:nobody /run \
+    && chown -R nobody:nobody /var/lib/nginx \
+    && chown -R nobody:nobody /var/www/html \
+    && chown -R nobody:nobody /var/log/nginx
 
 
 # Add configuration files

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,11 +59,8 @@ RUN apk --no-cache add \
 # Remove default server definition
     && rm /etc/nginx/http.d/default.conf \
 # Make sure files/folders needed by the processes are accessable when they run under the nobody user
-    && chown -R nobody:nobody /run \
-    && chown -R nobody:nobody /var/lib/nginx \
-    && chown -R nobody:nobody /var/www/html \
-    && chown -R nobody:nobody /var/log/nginx
-
+    && mkdir -p /run /var/lib/nginx /var/www/html /var/log/nginx \
+    && chown -R nobody:nobody /run /var/lib/nginx /var/www/html /var/log/nginx
 
 # Add configuration files
 COPY --chown=nobody rootfs/ /

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,9 +59,8 @@ RUN apk --no-cache add \
 # Remove default server definition
     && rm /etc/nginx/http.d/default.conf \
 # Make sure files/folders needed by the processes are accessable when they run under the nobody user
-    && chown -R nobody.nobody /run \
-    && chown -R nobody.nobody /var/lib/nginx \
-    && chown -R nobody.nobody /var/log/nginx
+    && chown -R nobody:nobody /var/www/html /run /var/lib/nginx /var/log/nginx
+
 
 # Add configuration files
 COPY --chown=nobody rootfs/ /


### PR DESCRIPTION

This PR cherry-picks the [PR #184](https://github.com/TrafeX/docker-php-nginx/pull/184) (thanks @everhard) to fix the `chown` command by replacing the period (.) with a colon (:) for separating user and group.

As per Linux standards and `chown` documentation, the colon is the correct delimiter, ensuring compatibility across different environments.

This change aligns with the standard usage, as explained in the original PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated ownership settings for key directories to improve clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->