### PR TITLE
feat: Add .gitattributes to preserve shell script execution permissions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Ensure shell scripts retain executable bit
+*.sh text eol=lf
+*.sh binary
+
+# Ensure entrypoint scripts retain executable bit
+**/docker-entrypoint.sh text eol=lf
+**/docker-entrypoint.sh binary
+
+# Default text files to use LF
+* text=auto eol=lf


### PR DESCRIPTION
This pull request includes changes to the `.gitattributes` file to ensure proper handling of shell scripts and entrypoint scripts, as well as setting default line endings for text files.

File handling improvements:

* [`.gitattributes`](diffhunk://#diff-618cd5b83d62060ba3d027e314a21ceaf75d36067ff820db126642944145393eR1-R10): Added rules to ensure shell scripts and entrypoint scripts retain their executable bits and use LF line endings. Also set default text files to use LF line endings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated configurations for handling shell scripts and text files to ensure proper execution and line endings across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->