### PR TITLE
Default locale

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,4 +96,5 @@ ENV nginx_root_directory=/var/www/html \
     post_max_size=8M \
     upload_max_filesize=2M \
     zlib_output_compression=On \
-    date_timezone=UTC
+    date_timezone=UTC \
+    intl_default_locale=en_US

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ You can define the next environment variables to change values from NGINX and PH
 | PHP8   | upload_max_filesize     | 2M            | Maximum size of an uploaded file.                                                                                                                                                                                                                      |
 | PHP8   | zlib_output_compression | On            | Whether to transparently compress pages. If this option is set to "On" in php.ini or the Apache configuration, pages are compressed if the browser sends an "Accept-Encoding: gzip" or "deflate" header.                                               |
 | PHP8   | date_timezone           | UTC           | Sets the PHP timezone configuration (date.timezone) in custom.ini. Accepts standard PHP timezone identifiers (e.g., 'America/New_York', 'Europe/London'). See [PHP timezones](https://www.php.net/manual/en/timezones.php) for valid values. |
+| PHP8   | intl_default_locale     | en_US         | If you want to change the [PHP locale](https://www.php.net/manual/en/class.locale.php) for the entire application or server globally (e.g. in php.ini), you can set the intl.default_locale directives (e.g. en_US or de_DE) |
 
 _Note; Because `-v` requires an absolute path I've added `pwd` in the example to return the absolute path to the current directory_
 

--- a/rootfs/etc/php83/conf.d/custom.ini
+++ b/rootfs/etc/php83/conf.d/custom.ini
@@ -13,3 +13,4 @@ post_max_size= $post_max_size
 upload_max_filesize= $upload_max_filesize
 zlib.output_compression= $zlib_output_compression
 date.timezone= "$date_timezone"
+intl.default_locale= "$intl_default_locale"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new environment variable `intl_default_locale` to set the default locale for PHP, enhancing internationalization support.
	- Updated documentation to include detailed instructions on the new environment variable and Composer installation process.

- **Documentation**
	- Enhanced the `README.md` with clear guidelines on the new locale configuration and multi-stage build examples for Composer.

- **Configuration**
	- Added `intl.default_locale` setting in the PHP configuration to utilize the new environment variable for locale management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->