### PR TITLE
Add feature to indicate version tags

### DIFF
--- a/.github/scripts/update-readme.sh
+++ b/.github/scripts/update-readme.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+set -eu
+
+INCLUDE_LATEST="${INCLUDE_LATEST:-false}"
+MAINTAINED_MINORS="${MAINTAINED_MINORS:-3}"
+REPO="${GITHUB_REPOSITORY:-erseco/alpine-php-webserver}"
+README="${README:-README.md}"
+
+[ -n "$REPO" ] || { echo "GITHUB_REPOSITORY is not defined (owner/repo)" >&2; exit 1; }
+
+BLOCK_START="<!-- supported-tags:start -->"
+BLOCK_END="<!-- supported-tags:end -->"
+
+# 1) Get all 3.x.y tags sorted
+TAGS=$(git tag -l '3.*.*' | sort -V)
+[ -n "$TAGS" ] || { echo "No 3.x.y tags found" >&2; exit 0; }
+
+# 2) For each minor, keep the highest patch version
+BEST=$(echo "$TAGS" | awk -F. '
+  {
+    if ($1 != 3) next
+    m = $1 "." $2
+    last[m] = $0
+  }
+  END {
+    for (m in last) print m, last[m]
+  }
+' | sort -V -k1,1)
+
+# 3) Select the last N minors and reverse the order
+SEL=$(echo "$BEST" | tail -n "$MAINTAINED_MINORS" | awk '{ lines[NR]=$0 } END { for (i=NR;i>0;i--) print lines[i] }')
+
+[ -n "$SEL" ] || { echo "No minors selected" >&2; exit 0; }
+
+# 4) Build the block
+BLOCK=""
+first=1
+for entry in $SEL; do
+  set -- $entry
+done
+
+# Trick: iterate line by line
+echo "$SEL" | while read -r minor full; do
+  if [ "$first" -eq 1 ]; then
+    line="- \`3\`, \`$minor\`, \`$full\`"
+    if [ "$INCLUDE_LATEST" = "true" ]; then
+      line="$line, \`latest\`"
+    fi
+    url="https://github.com/${REPO}/blob/${full}/Dockerfile"
+    echo "${line} ([Dockerfile](${url}))"
+    first=0
+  else
+    url="https://github.com/${REPO}/blob/${full}/Dockerfile"
+    echo "- \`${minor}\`, \`${full}\` ([Dockerfile](${url}))"
+  fi
+done > supported-tags.tmp
+
+# 5) Replace the block in README
+awk -v start="$BLOCK_START" -v end="$BLOCK_END" '
+  BEGIN { inblk=0 }
+  {
+    if ($0 ~ start) {
+      print $0
+      while ((getline line < "supported-tags.tmp") > 0) print line
+      inblk=1
+      next
+    }
+    if ($0 ~ end) {
+      inblk=0
+    }
+    if (!inblk) print $0
+  }
+' "$README" > "${README}.new"
+
+mv "${README}.new" "$README"
+rm -f supported-tags.tmp
+
+echo "README updated."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   buildx:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
       security-events: write
       
@@ -129,6 +129,28 @@ jobs:
           exit-code: '0'
           severity: 'CRITICAL,HIGH'
 
+      - name: Generate Supported Tags block
+        if: github.event_name != 'pull_request'
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          # true if the tag belongs to main (your same logic)
+          INCLUDE_LATEST: ${{ github.ref_type == 'tag' && steps.mainline.outputs.is_main == 'true' && 'true' || 'false' }}
+          MAINTAINED_MINORS: "3"
+        run: |
+          .github/scripts/update-readme.sh
+
+      - name: Commit README if changed
+        if: github.event_name != 'pull_request'
+        run: |
+          if ! git diff --quiet -- README.md; then
+            git config user.name "github-actions"
+            git config user.email "github-actions@users.noreply.github.com"
+            git add README.md
+            git commit -m "chore(readme): update supported tags"
+            git push
+          else
+            echo "No README changes to commit."
+          fi
 
       # Update Docker Hub Description
       - name: Docker Hub Description

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Repository: https://github.com/erseco/alpine-php-webserver
 * The logs of all the services are redirected to the output of the Docker container (visible with `docker logs -f <container name>`)
 * Follows the KISS principle (Keep It Simple, Stupid) to make it easy to understand and adjust the image to your needs
 
+## Supported tags and respective Dockerfile links
+<!-- supported-tags:start -->
+- `3`, `3.22`, `3.22.1` ([Dockerfile](https://github.com/erseco/alpine-php-webserver/blob/3.22.1/Dockerfile))
+- `3.21`, `3.21.4` ([Dockerfile](https://github.com/erseco/alpine-php-webserver/blob/3.21.4/Dockerfile))
+- `3.20`, `3.20.7` ([Dockerfile](https://github.com/erseco/alpine-php-webserver/blob/3.20.7/Dockerfile))
+<!-- supported-tags:end -->
+
 ## Usage
 
 Start the Docker container:


### PR DESCRIPTION
This pull request automates the process of updating the "Supported tags" section in the `README.md` file to reflect the latest maintained minor versions of the Docker image, and integrates this update into the CI workflow. The main changes include adding a shell script to generate the supported tags block, modifying workflow permissions, and updating the build workflow to run and commit these changes automatically.

**Automation of README supported tags block:**

* Added `.github/scripts/update-readme.sh` to generate and update the supported tags section in `README.md`, listing the latest patch for each maintained minor version and linking to the corresponding `Dockerfile`.
* Updated `README.md` to include a new "Supported tags and respective Dockerfile links" section, with a block that will be automatically maintained by the new script.

**CI workflow integration:**

* Modified `.github/workflows/build.yml` to grant write permissions to `contents` so that workflow jobs can commit changes to the repository.
* Added steps to the build workflow to run the supported tags update script after a successful build (excluding pull requests), and commit and push changes to `README.md` if any updates are detected.