### PR TITLE
Add feature to indicate version tags

### DIFF
--- a/.github/scripts/update-readme.sh
+++ b/.github/scripts/update-readme.sh
@@ -35,25 +35,21 @@ SEL=$(echo "$BEST" | tail -n "$MAINTAINED_MINORS" | awk '{ lines[NR]=$0 } END { 
 # 4) Build the block
 BLOCK=""
 first=1
-for entry in $SEL; do
-  set -- $entry
-done
 
-# Trick: iterate line by line
 echo "$SEL" | while read -r minor full; do
   if [ "$first" -eq 1 ]; then
-    line="- \`3\`, \`$minor\`, \`$full\`"
-    if [ "$INCLUDE_LATEST" = "true" ]; then
-      line="$line, \`latest\`"
-    fi
+    # newest minor → include all aliases: latest, 3, minor, full
+    line="- \`latest\`, \`3\`, \`$minor\`, \`$full\`"
     url="https://github.com/${REPO}/blob/${full}/Dockerfile"
     echo "${line} ([Dockerfile](${url}))"
     first=0
   else
+    # older minors → only minor and full
     url="https://github.com/${REPO}/blob/${full}/Dockerfile"
     echo "- \`${minor}\`, \`${full}\` ([Dockerfile](${url}))"
   fi
 done > supported-tags.tmp
+
 
 # 5) Replace the block in README
 awk -v start="$BLOCK_START" -v end="$BLOCK_END" '

--- a/README.md
+++ b/README.md
@@ -30,8 +30,7 @@ Repository: https://github.com/erseco/alpine-php-webserver
 - `3.20`, `3.20.7` ([Dockerfile](https://github.com/erseco/alpine-php-webserver/blob/3.20.7/Dockerfile))
 <!-- supported-tags:end -->
 
-> **Note**: The [`main` branch](https://github.com/erseco/alpine-php-webserver/blob/main/Dockerfile)  
-> is automatically pushed with the tag **`beta`**.  
+> **Note**: The `main` branch ([Dockerfile](https://github.com/erseco/alpine-php-webserver/blob/main/Dockerfile)) is automatically pushed with the tag **`beta`**.  
 > Use this tag for testing purposes before stable releases are published.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -25,10 +25,14 @@ Repository: https://github.com/erseco/alpine-php-webserver
 
 ## Supported tags and respective Dockerfile links
 <!-- supported-tags:start -->
-- `3`, `3.22`, `3.22.1` ([Dockerfile](https://github.com/erseco/alpine-php-webserver/blob/3.22.1/Dockerfile))
+- `latest`, `3`, `3.22`, `3.22.1` ([Dockerfile](https://github.com/erseco/alpine-php-webserver/blob/3.22.1/Dockerfile))
 - `3.21`, `3.21.4` ([Dockerfile](https://github.com/erseco/alpine-php-webserver/blob/3.21.4/Dockerfile))
 - `3.20`, `3.20.7` ([Dockerfile](https://github.com/erseco/alpine-php-webserver/blob/3.20.7/Dockerfile))
 <!-- supported-tags:end -->
+
+> **Note**: The [`main` branch](https://github.com/erseco/alpine-php-webserver/blob/main/Dockerfile)  
+> is automatically pushed with the tag **`beta`**.  
+> Use this tag for testing purposes before stable releases are published.
 
 ## Usage
 


### PR DESCRIPTION
This pull request updates how supported Docker tags are displayed in the `README.md` and improves the related script for generating these tags. The main change is that the newest minor version now includes all possible aliases, including `latest`, making it easier for users to find and use the recommended tag. Additionally, a note has been added to clarify the purpose of the `beta` tag.

**Supported tags display improvements:**

* The newest minor version now lists all aliases: `latest`, `3`, minor, and full version, making it clearer which tag is recommended for general use. (`README.md`, `.github/scripts/update-readme.sh`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L28-R36) [[2]](diffhunk://#diff-252c59e408b5d9381d53eda9b615ed03b28b2f2cb6b613d0a8f0bdd88b1b729bL38-R53)
* Older minor versions continue to show only the minor and full version tags for simplicity. (`.github/scripts/update-readme.sh`)

**Documentation clarity:**

* Added a note to the `README.md` explaining that the `main` branch is automatically pushed as the `beta` tag, which is intended for testing before stable releases. (`README.md`)