### PR TITLE
Increased version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG ARCH=
-FROM ${ARCH}alpine:3.22
+FROM ${ARCH}alpine:3.23
 
 LABEL Maintainer="Ernesto Serrano <info@ernesto.es>" \
       Description="Lightweight container with Nginx & PHP-FPM based on Alpine Linux."

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Docker PHP-FPM 8.4 & Nginx 1.28 on Alpine Linux 3.22
+# Docker PHP-FPM 8.4 & Nginx 1.28 on Alpine Linux 3.23
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/erseco/alpine-php-webserver.svg)](https://hub.docker.com/r/erseco/alpine-php-webserver/)
 ![Docker Image Size](https://img.shields.io/docker/image-size/erseco/alpine-php-webserver)
-![alpine 3.22](https://img.shields.io/badge/alpine-3.22-brightgreen.svg)
+![alpine 3.23](https://img.shields.io/badge/alpine-3.23-brightgreen.svg)
 ![nginx 1.28](https://img.shields.io/badge/nginx-1.28-brightgreen.svg)
 ![php 8.4](https://img.shields.io/badge/php-8.4-brightgreen.svg)
 ![License MIT](https://img.shields.io/badge/license-MIT-blue.svg)


### PR DESCRIPTION
This pull request updates the base Alpine Linux version used in the project from 3.22 to 3.23. This change ensures that the container uses the latest stable release, which may include important security patches and improvements.

Base image update:

* Updated the `Dockerfile` to use `alpine:3.23` as the base image instead of `alpine:3.22`.
* Updated all references in `README.md` to reflect the new Alpine Linux version (3.23).