### PR TITLE
docs: publish full documentation site with Zensical + GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,66 @@
+name: docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Zensical
+        run: pip install --default-timeout=120 zensical
+
+      - name: Build site
+        run: zensical build --clean
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: site
+
+  deploy:
+    if: github.event_name != 'pull_request'
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .aider*
 .env
+/site
+/.venv

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Docker PHP-FPM 8.4 & Nginx 1.28 on Alpine Linux 3.23
+# Alpine PHP Webserver
 
 [![Docker Pulls](https://img.shields.io/docker/pulls/erseco/alpine-php-webserver.svg)](https://hub.docker.com/r/erseco/alpine-php-webserver/)
 ![Docker Image Size](https://img.shields.io/docker/image-size/erseco/alpine-php-webserver)
@@ -7,23 +7,41 @@
 ![php 8.4](https://img.shields.io/badge/php-8.4-brightgreen.svg)
 ![License MIT](https://img.shields.io/badge/license-MIT-blue.svg)
 
-Example PHP-FPM 8.4 & Nginx 1.28 setup for Docker, build on [Alpine Linux](https://www.alpinelinux.org/).
-The image is only +/- 25MB large.
+A minimal **Nginx + PHP-FPM** Docker image built on [Alpine Linux](https://www.alpinelinux.org/) — ~25 MB, multi-arch, configured entirely through environment variables.
 
-Repository: https://github.com/erseco/alpine-php-webserver
+> 📚 **Full documentation: <https://erseco.github.io/alpine-php-webserver/>**
 
-* Built on the lightweight and secure Alpine Linux distribution
-* Very small Docker image size (+/-25MB)
-* Uses PHP 8.4 for better performance, lower cpu usage & memory footprint
-* Multi-arch support: 386, amd64, arm/v6, arm/v7, arm64, ppc64le, s390x
-* Optimized for 100 concurrent users
-* Optimized to only use resources when there's traffic (by using PHP-FPM's ondemand PM)
-* Use of runit instead of supervisord to reduce memory footprint
-* The servers Nginx, PHP-FPM run under a non-privileged user (nobody) to make it more secure
-* The logs of all the services are redirected to the output of the Docker container (visible with `docker logs -f <container name>`)
-* Follows the KISS principle (Keep It Simple, Stupid) to make it easy to understand and adjust the image to your needs
+The documentation site covers quick start, Docker Compose recipes, Nginx/PHP configuration, reverse proxy and trusted-IP setups (Traefik, Nginx, Cloudflare, Cloudflare Tunnel), a complete environment variable reference, Composer/build recipes, how to extend the image with `runit` daemons and init scripts, the healthcheck and logging story, and a troubleshooting section built from the most frequent support questions.
+
+## Quick start
+
+```bash
+docker run --rm -p 8080:8080 erseco/alpine-php-webserver
+```
+
+Open <http://localhost:8080/> to see `phpinfo()`, or <http://localhost:8080/test.html> for the static probe.
+
+Mount your own code:
+
+```bash
+docker run --rm -p 8080:8080 -v "$PWD/php:/var/www/html" erseco/alpine-php-webserver
+```
+
+Compose:
+
+```yaml
+services:
+  web:
+    image: erseco/alpine-php-webserver
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./php:/var/www/html
+    restart: unless-stopped
+```
 
 ## Supported tags and respective Dockerfile links
+
 <!-- supported-tags:start -->
 - `latest`, `3`, `3.23`, `3.23.3` ([Dockerfile](https://github.com/erseco/alpine-php-webserver/blob/3.23.3/Dockerfile))
 - `3.22`, `3.22.2` ([Dockerfile](https://github.com/erseco/alpine-php-webserver/blob/3.22.2/Dockerfile))
@@ -31,259 +49,100 @@ Repository: https://github.com/erseco/alpine-php-webserver
 - `3.20`, `3.20.8` ([Dockerfile](https://github.com/erseco/alpine-php-webserver/blob/3.20.8/Dockerfile))
 <!-- supported-tags:end -->
 
-> **Note**: The `main` branch ([Dockerfile](https://github.com/erseco/alpine-php-webserver/blob/main/Dockerfile)) is automatically pushed with the tag **`beta`**.  
-> Use this tag for testing purposes before stable releases are published.
-
-## Usage
-
-Start the Docker container:
-
-    docker run -p 80:8080 erseco/alpine-php-webserver
-
-See the PHP info on http://localhost, or the static html page on http://localhost/test.html
-
-Or mount your own code to be served by PHP-FPM & Nginx
-
-    docker run -p 80:8080 -v ~/my-codebase:/var/www/html erseco/alpine-php-webserver
-
-## Running with Docker Compose
-
-Easily serve your local PHP files using Docker Compose. This setup mounts your `./php` directory and binds it to port 8080 on your local machine, allowing for immediate reflection of changes in your PHP files through a web server. It's perfect for local development and testing.
-
-### Docker Compose Configuration
-
-Here's a simple `docker-compose.yml` example to get you started:
-
-```yaml
-services:
-  webserver:
-    image: erseco/alpine-php-webserver
-    ports:
-      - 8080:8080
-    volumes:
-      - ./php:/var/www/html
-    restart: unless-stopped
-```
-
-- **image**: Uses `erseco/alpine-php-webserver`, optimized for PHP applications.
-- **ports**: Maps port 8080 from the container to your local machine, accessible at `http://localhost:8080`.
-- **volumes**: Mounts your local `./php` directory to `/var/www/html` in the container, enabling live updates to your PHP files.
-- **restart**: Ensures the container automatically restarts unless manually stopped, for better reliability.
-
-### How to Use
-
-1. Save the above `docker-compose.yml` in your project directory.
-2. Run `docker compose up -d` in your terminal, within the same directory.
-3. Access your PHP application at `http://localhost:8080`.
-
-This method ensures a seamless development process, allowing you to focus on coding rather than setup complexities.
-
-## Adding additional daemons
-You can add additional daemons (e.g. your own app) to the image by creating runit entries. You only have to write a small shell script which runs your daemon, and runit will keep it up and running for you, restarting it when it crashes, etc.
-
-The shell script must be called `run`, must be executable, and is to be placed in the directory `/etc/service/<NAME>`.
-
-Here's an example showing you how a memcached server runit entry can be made.
-
-    #!/bin/sh
-    ### In memcached.sh (make sure this file is chmod +x):
-    # `chpst -u memcache` runs the given command as the user `memcache`.
-    # If you omit that part, the command will be run as root.
-    exec 2>&1 chpst -u memcache /usr/bin/memcached
-
-    ### In Dockerfile:
-    RUN mkdir /etc/service/memcached
-    ADD memcached.sh /etc/service/memcached/run
-
-Note that the shell script must run the daemon **without letting it daemonize/fork it**. Usually, daemons provide a command line flag or a config file option for that.
-
-
-## Running scripts during container startup
-You can set your own scripts during startup, just add your scripts in `/docker-entrypoint-init.d/`. The scripts are run in lexicographic order.
-
-All scripts must exit correctly, e.g. with exit code 0. If any script exits with a non-zero exit code, the booting will fail.
-
-The following example shows how you can add a startup script. This script simply logs the time of boot to the file /tmp/boottime.txt.
-
-    #!/bin/sh
-    ### In logtime.sh (make sure this file is chmod +x):
-    date > /tmp/boottime.txt
-
-    ### In Dockerfile:
-    ADD logtime.sh /docker-entrypoint-init.d/logtime.sh
-
-
-## Nginx Configuration
-
-The Nginx configuration is designed to be flexible and easy to customize. By default, the main configuration file is located at `rootfs/etc/nginx/nginx.conf`. 
-
-### Adding Custom Configurations
-
-You can add custom configurations in two ways:
-
-1. **Global Configurations**: Place your configuration files in `/etc/nginx/conf.d/`. These configurations are included globally and affect all server blocks.
-
-2. **Server-Specific Configurations**: For configurations specific to a particular server block, place your files in `/etc/nginx/server-conf.d/`. These are included within the server block, allowing for more granular control.
-
-### Example
-
-To add a custom configuration, create a `.conf` file in the appropriate directory. For example, to add a server-specific rule, you might create a file named `custom-server.conf` in `/etc/nginx/server-conf.d/` with the following content:
-
-```nginx
-# Example custom server configuration
-location /custom {
-    return 200 'Custom server configuration is working!';
-    add_header Content-Type text/plain;
-}
-```
-
-This setup allows you to easily manage and customize your Nginx configurations without modifying the main `nginx.conf` file.
-In [rootfs/etc/](rootfs/etc/) you'll find the default configuration files for Nginx, PHP and PHP-FPM.
-If you want to extend or customize that you can do so by mounting a configuration file in the correct folder;
-
-Nginx configuration:
-
-    docker run -v "`pwd`/nginx-server.conf:/etc/nginx/conf.d/server.conf" erseco/alpine-php-webserver
-
-PHP configuration:
-
-    docker run -v "`pwd`/php-setting.ini:/etc/php8/conf.d/settings.ini" erseco/alpine-php-webserver
-
-PHP-FPM configuration:
-
-    docker run -v "`pwd`/php-fpm-settings.conf:/etc/php8/php-fpm.d/server.conf" erseco/alpine-php-webserver
-
-## Environment variables
-
-You can define the next environment variables to change values from NGINX and PHP
-
-| Server | Variable Name                 | Default       | description                                                                                                                                                                                                                                  |
-|--------|-------------------------------|---------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| NGINX  | nginx_root_directory          | /var/www/html | Sets the root directory for the NGINX server, which specifies the location from which files are served. This is the directory where your web application's public files should reside.                                                       |
-| NGINX  | client_max_body_size          | 2m            | Sets the maximum allowed size of the client request body, specified in the “Content-Length” request header field.                                                                                                                            |
-| NGINX  | fastcgi_read_timeout          | 60s           | Defines a timeout for reading a response from the FastCGI server.                                                                                                                                                                            |
-| NGINX  | fastcgi_send_timeout          | 60s           | Sets a timeout for transmitting a request to the FastCGI server.                                                                                                                                                                             |
-| NGINX  | DISABLE_DEFAULT_LOCATION      | false         | If set to "true", this variable disables the default `location /` block in the Nginx configuration. This allows you to mount a custom configuration in `/etc/nginx/server-conf.d/` without conflicts.                                        |
-| NGINX  | REAL_IP_HEADER                | X-Forwarded-For | Selects the header NGINX should trust for the original client IP when `REAL_IP_FROM` is configured. Common values are `X-Forwarded-For` and `CF-Connecting-IP`.                                                                            |
-| NGINX  | REAL_IP_RECURSIVE             | off           | Controls whether NGINX walks the trusted proxy chain recursively when resolving the client IP. Accepted values are `on` and `off`.                                                                                                         |
-| NGINX  | REAL_IP_FROM                  | *(empty)*     | Comma-separated list of trusted proxy IPs/CIDRs for `set_real_ip_from`. Real IP restoration stays disabled until this variable is set.                                                                                                      |
-| PHP8   | clear_env                     | no            | Clear environment in FPM workers. Prevents arbitrary environment variables from reaching FPM worker processes by clearing the environment in workers before env vars specified in this pool configuration are added.                         |
-| PHP8   | allow_url_fopen               | On            | Enable the URL-aware fopen wrappers that enable accessing URL object like files. Default wrappers are provided for the access of remote files using the ftp or http protocol, some extensions like zlib may register additional wrappers.    |
-| PHP8   | allow_url_include             | Off           | Allow the use of URL-aware fopen wrappers with the following functions: include(), include_once(), require(), require_once().                                                                                                                |
-| PHP8   | display_errors                | Off           | Determine whether errors should be printed to the screen as part of the output or if they should be hidden from the user.                                                                                                                    |
-| PHP8   | file_uploads                  | On            | Whether or not to allow HTTP file uploads.                                                                                                                                                                                                   |
-| PHP8   | max_execution_time            | 0             | Maximum time in seconds a script is allowed to run before it is terminated by the parser. This helps prevent poorly written scripts from tying up the server. The default setting is 30.                                                     |
-| PHP8   | max_input_time                | -1            | Maximum time in seconds a script is allowed to parse input data, like POST, GET and file uploads.                                                                                                                                            |
-| PHP8   | max_input_vars                | 1000          | Maximum number of input variables allowed per request and can be used to deter denial of service attacks involving hash collisions on the input variable names.                                                                              |
-| PHP8   | memory_limit                  | 128M          | Maximum amount of memory in bytes that a script is allowed to allocate. This helps prevent poorly written scripts for eating up all available memory on a server. Note that to have no memory limit, set this directive to -1.               |
-| PHP8   | post_max_size                 | 8M            | Max size of post data allowed. This setting also affects file upload. To upload large files, this value must be larger than upload_max_filesize. Generally speaking, memory_limit should be larger than post_max_size.                       |
-| PHP8   | upload_max_filesize           | 2M            | Maximum size of an uploaded file.                                                                                                                                                                                                            |
-| PHP8   | zlib_output_compression       | On            | Whether to transparently compress pages. If this option is set to "On" in php.ini or the Apache configuration, pages are compressed if the browser sends an "Accept-Encoding: gzip" or "deflate" header.                                     |
-| PHP8   | date_timezone                 | UTC           | Sets the PHP timezone configuration (date.timezone) in custom.ini. Accepts standard PHP timezone identifiers (e.g., 'America/New_York', 'Europe/London'). See [PHP timezones](https://www.php.net/manual/en/timezones.php) for valid values. |
-| PHP8   | intl_default_locale           | en_US         | If you want to change the [PHP locale](https://www.php.net/manual/en/class.locale.php) for the entire application or server globally (e.g. in php.ini), you can set the intl.default_locale directives (e.g. en_US or de_DE)                 |
-| PHP8   | opcache_enable                | 0             | Enables/disables OPcache. Set to `1` to enable OPcache for better performance in production.                                                                                                                                                 |
-| PHP8   | opcache_memory_consumption    | 256           | The size of the OPcache shared memory storage in megabytes.                                                                                                                                                                                  |
-| PHP8   | opcache_max_accelerated_files | 20000         | The maximum number of keys (and files) in the OPcache hash table.                                                                                                                                                                            |
-| PHP8   | opcache_validate_timestamps   | 0             | When set to `0`, OPcache doesn't check if files have changed, which is recommended for production. After each deployment, the cache must be cleared manually. Set to `1` for development.                                                    |
-| PHP8   | opcache_preload               | *(empty)*     | Specifies a PHP script to be compiled and executed at server start-up, improving performance. See [PHP Preloading](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.preload). Example: `/var/www/html/config/preload.php` |
-| PHP8   | realpath_cache_size           | 4096K         | The size of the realpath cache to be used by PHP.                                                                                                                                                                                            |
-| PHP8   | realpath_cache_ttl            | 600           | The time-to-live for the realpath cache.                                                                                                                                                                                                     |
-
-### Trusted proxy real IP support
-
-Trusted proxy real IP restoration is disabled by default. The image only enables NGINX `real_ip_*` directives when `REAL_IP_FROM` contains one or more explicit trusted proxy ranges.
-
-Only trust proxy IPs or CIDRs that are under your control. Do **not** set `REAL_IP_FROM` to broad public ranges such as `0.0.0.0/0`, because that would allow clients to spoof `X-Forwarded-For` or similar headers.
-
-Generic reverse proxy example:
-
-```bash
-docker run \
-  -e REAL_IP_HEADER=X-Forwarded-For \
-  -e REAL_IP_RECURSIVE=on \
-  -e REAL_IP_FROM=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 \
-  erseco/alpine-php-webserver
-```
-
-Cloudflare example:
-
-```bash
-docker run \
-  -e REAL_IP_HEADER=CF-Connecting-IP \
-  -e REAL_IP_RECURSIVE=on \
-  -e REAL_IP_FROM=173.245.48.0/20,103.21.244.0/22 \
-  erseco/alpine-php-webserver
-```
-
-Use the full set of Cloudflare proxy ranges that apply to your deployment, not just the sample CIDRs above. Cloudflare publishes the current list here: <https://developers.cloudflare.com/fundamentals/concepts/cloudflare-ip-addresses/>.
-
-Cloudflare Tunnel / Zero Trust example:
-
-```bash
-docker run \
-  -e REAL_IP_HEADER=CF-Connecting-IP \
-  -e REAL_IP_RECURSIVE=on \
-  -e REAL_IP_FROM=172.16.0.0/12 \
-  erseco/alpine-php-webserver
-```
-
-For Tunnel or Zero Trust setups, trust only the private IP range of your tunnel connector or ingress proxy.
-
-## Adding composer
-
-If you need [Composer](https://getcomposer.org/) in your project, here's an easy way to add it.
-
-```dockerfile
-FROM erseco/alpine-php-webserver:latest
-USER root
-# Install composer from the official image
-RUN apk add --no-cache composer
-USER nobody
-# Run composer install to install the dependencies
-RUN composer install --optimize-autoloader --no-interaction --no-progress
-```
-
-### Building with Composer
-
-If you are building an image that includes your source code and uses Composer to manage dependencies, it's recommended to install the dependencies during the image build process.
-
-Although Composer (`/usr/bin/composer`) is required to install the dependencies, it does not need to remain in the final image. If you're building for production and want a leaner image, you can uninstall it after running `composer install` using `apk del`.
-
-```Dockerfile
-FROM erseco/alpine-php-webserver
-
-# Switch to root to install Composer
-USER root
-
-# Install Composer and required tools
-RUN apk add --no-cache composer
-
-# Copy application source code
-COPY ./ /var/www/html
-WORKDIR /var/www/html
-
-# Switch to a non-root user for running Composer
-USER nobody
-
-# Install PHP dependencies (requires composer.json)
-RUN composer install \
-    --no-dev \
-    --optimize-autoloader \
-    --no-interaction \
-    --no-progress
-
-# Optional: remove Composer to reduce image size
-USER root
-RUN apk del composer
-USER nobody
-```
-
-This keeps the final image clean, reduces its size, and minimizes the available tooling that could be misused in production environments.
+> **Note**: The `main` branch ([Dockerfile](https://github.com/erseco/alpine-php-webserver/blob/main/Dockerfile)) is automatically pushed with the tag **`beta`**. Use this tag for testing purposes before stable releases are published.
+
+## Key features
+
+- Compact image (~25 MB) built on Alpine Linux
+- PHP 8.4 FPM with `ondemand` process manager — idles near-zero CPU
+- Unix-socket FastCGI between Nginx and PHP-FPM
+- Healthcheck on `/fpm-ping` (localhost-only by design)
+- Trusted-proxy real IP support (`REAL_IP_FROM`, Cloudflare, Tunnel)
+- `DISABLE_DEFAULT_LOCATION` for full routing control
+- Custom Nginx snippets via `/etc/nginx/conf.d/` and `/etc/nginx/server-conf.d/`
+- Custom PHP settings via environment variables or `/etc/php84/conf.d/*.ini`
+- Extra daemons via `runit` (`/etc/service/<name>/run`)
+- Startup scripts via `/docker-entrypoint-init.d/`
+- Non-privileged `nobody` user; logs on `stdout` / `stderr`
+- Multi-arch: `amd64`, `arm64`, `arm/v7`, `arm/v6`, `386`, `ppc64le`, `s390x`
 
 ## Running Commands as Root
 
-In certain situations, you might need to run commands as `root` within your Moodle container, for example, to install additional packages. You can do this using the `docker compose exec` command with the `--user root` option. Here's how:
+The container runs as `nobody`. When you need root (installing extra Alpine packages for debugging, inspecting file ownership, etc.), use `docker compose exec` with `--user root`:
 
 ```bash
-docker compose exec --user root alpine-php-webserver sh
+docker compose exec --user root web sh
 ```
+
+Example — install debug tools on a running container:
+
+```bash
+docker compose exec --user root web sh -c "apk update && apk add nano curl htop"
+```
+
+## Environment Variables
+
+The most-requested reference. The full grouped reference (with OPcache, real IP, reverse proxy recipes) lives at <https://erseco.github.io/alpine-php-webserver/environment-variables/>.
+
+| Server | Variable Name                 | Default         | Description |
+|--------|-------------------------------|-----------------|-------------|
+| NGINX  | `nginx_root_directory`        | `/var/www/html` | Document root for the default server block. |
+| NGINX  | `client_max_body_size`        | `2M`            | Max allowed client request body. |
+| NGINX  | `fastcgi_read_timeout`        | `60s`           | Max time waiting for a response from PHP-FPM. |
+| NGINX  | `fastcgi_send_timeout`        | `60s`           | Max time transmitting a request to PHP-FPM. |
+| NGINX  | `DISABLE_DEFAULT_LOCATION`    | `false`         | When `true`, comments out the default `location /` block so you can mount your own via `/etc/nginx/server-conf.d/`. |
+| NGINX  | `REAL_IP_HEADER`              | `X-Forwarded-For` | Header Nginx trusts as the real client IP (`X-Forwarded-For`, `CF-Connecting-IP`, …). |
+| NGINX  | `REAL_IP_RECURSIVE`           | `off`           | `on` to walk the trusted proxy chain recursively. |
+| NGINX  | `REAL_IP_FROM`                | *(empty)*       | Comma-separated list of trusted proxy IPs / CIDRs. Real IP stays disabled until set. |
+| PHP8   | `clear_env`                   | `no`            | Keep env vars available to FPM workers. |
+| PHP8   | `allow_url_fopen`             | `On`            | Enable URL-aware fopen wrappers. |
+| PHP8   | `allow_url_include`           | `Off`           | Allow `include()` / `require()` from URLs. |
+| PHP8   | `display_errors`              | `Off`           | Render errors in HTTP responses. |
+| PHP8   | `file_uploads`                | `On`            | Enable HTTP uploads. |
+| PHP8   | `max_execution_time`          | `0`             | Max script runtime in seconds. `0` = unlimited. |
+| PHP8   | `max_input_time`              | `-1`            | Max input parsing time in seconds. `-1` = unlimited. |
+| PHP8   | `max_input_vars`              | `1000`          | Max POST/GET variables per request. |
+| PHP8   | `memory_limit`                | `128M`          | Per-request memory ceiling. `-1` = unlimited. |
+| PHP8   | `post_max_size`               | `8M`            | Max POST body. Must exceed `upload_max_filesize`. |
+| PHP8   | `upload_max_filesize`         | `2M`            | Max individual file upload size. |
+| PHP8   | `zlib_output_compression`     | `On`            | Transparent output compression. |
+| PHP8   | `date_timezone`               | `UTC`           | PHP `date.timezone`. |
+| PHP8   | `intl_default_locale`         | `en_US`         | PHP `intl.default_locale`. |
+| PHP8   | `opcache_enable`              | `0`             | `1` to enable OPcache. |
+| PHP8   | `opcache_memory_consumption`  | `256`           | Shared memory in MB. |
+| PHP8   | `opcache_max_accelerated_files`| `20000`        | Max cached files. |
+| PHP8   | `opcache_validate_timestamps` | `0`             | `0` = production (restart on deploy); `1` = development. |
+| PHP8   | `opcache_preload`             | *(empty)*       | Preload script path. |
+| PHP8   | `realpath_cache_size`         | `4096K`         | Realpath cache size. |
+| PHP8   | `realpath_cache_ttl`          | `600`           | Realpath cache TTL in seconds. |
+
+## Registries
+
+- Docker Hub: `erseco/alpine-php-webserver`
+- GitHub Container Registry: `ghcr.io/erseco/alpine-php-webserver`
+
+## Documentation
+
+The full, searchable documentation lives at **<https://erseco.github.io/alpine-php-webserver/>**:
+
+- [Quick Start](https://erseco.github.io/alpine-php-webserver/quick-start/)
+- [Docker Compose examples](https://erseco.github.io/alpine-php-webserver/docker-compose/)
+- [Nginx configuration](https://erseco.github.io/alpine-php-webserver/nginx/)
+- [PHP configuration](https://erseco.github.io/alpine-php-webserver/php/)
+- [Environment variables reference](https://erseco.github.io/alpine-php-webserver/environment-variables/)
+- [Reverse proxy & trusted IPs](https://erseco.github.io/alpine-php-webserver/reverse-proxy/)
+- [Composer & building your own image](https://erseco.github.io/alpine-php-webserver/composer/)
+- [Extending the image](https://erseco.github.io/alpine-php-webserver/extending/)
+- [Healthcheck & logs](https://erseco.github.io/alpine-php-webserver/healthcheck-logs/)
+- [Troubleshooting](https://erseco.github.io/alpine-php-webserver/troubleshooting/)
+- [FAQ](https://erseco.github.io/alpine-php-webserver/faq/)
+
+## Contributing
+
+Issues and pull requests are welcome: <https://github.com/erseco/alpine-php-webserver/issues>.
+
+Documentation sources live under [`docs/`](docs/) and are built with [Zensical](https://zensical.org/) via the `docs.yml` GitHub Actions workflow.
+
+## License
+
+[MIT](LICENSE)

--- a/docs/composer.md
+++ b/docs/composer.md
@@ -1,0 +1,146 @@
+# Composer & Building Your Own Image
+
+`alpine-php-webserver` intentionally ships **without** Composer so the base image stays at ~25 MB. For projects that need Composer, build a thin image on top.
+
+## Development: install Composer at runtime
+
+Good for quickly testing a project without building a custom image:
+
+```bash
+docker run --rm -it \
+  -v "$PWD:/var/www/html" \
+  -w /var/www/html \
+  --user root \
+  erseco/alpine-php-webserver \
+  sh -c "apk add --no-cache composer && composer install"
+```
+
+!!! tip
+    Use this only for one-off tasks. Adding packages at runtime every boot is slow and leaves you without reproducible builds.
+
+## Production: bake Composer into your image
+
+This is the pattern you want for CI/CD pipelines:
+
+```dockerfile
+FROM erseco/alpine-php-webserver:latest
+
+USER root
+RUN apk add --no-cache composer
+
+COPY --chown=nobody:nobody ./ /var/www/html
+WORKDIR /var/www/html
+
+USER nobody
+
+RUN composer install \
+    --no-dev \
+    --optimize-autoloader \
+    --no-interaction \
+    --no-progress
+
+USER root
+RUN apk del composer
+USER nobody
+```
+
+Build it:
+
+```bash
+docker build -t myapp:latest .
+docker run --rm -p 8080:8080 myapp:latest
+```
+
+Things to note:
+
+- **`COPY --chown=nobody:nobody`** — the image runs as `nobody`. Without this, files will be owned by root and PHP-FPM will see them, but cache/log directories will not be writable.
+- **`WORKDIR /var/www/html`** — Composer must run in the directory that actually contains `composer.json` ([#40](https://github.com/erseco/alpine-php-webserver/issues/40)). Running it somewhere else produces *"Composer could not find a composer.json file in /var/www/html"*.
+- **`USER nobody` before `composer install`** — Composer writes to `vendor/`, which has to end up owned by `nobody` so the runtime user can read it. Running Composer as root is legal but then you need an extra `chown`.
+- **Removing Composer after install** is optional but recommended — it trims about 5 MB and removes a tool attackers could misuse inside the container.
+
+## Multi-stage builds
+
+For bigger projects, split dependencies and runtime:
+
+```dockerfile
+# ---- build stage ----
+FROM composer:2 AS build
+
+WORKDIR /app
+COPY composer.json composer.lock ./
+RUN composer install --no-dev --optimize-autoloader --no-interaction --no-progress
+
+COPY . .
+RUN composer dump-autoload --no-dev --classmap-authoritative
+
+# ---- runtime stage ----
+FROM erseco/alpine-php-webserver:latest
+
+COPY --from=build --chown=nobody:nobody /app /var/www/html
+WORKDIR /var/www/html
+```
+
+Advantages:
+
+- Runtime image stays tiny (no Composer binary, no build cache).
+- `vendor/` is installed once during the build stage, not on every container start.
+- Works great with BuildKit cache mounts for even faster builds.
+
+## Private Composer packages
+
+Private repositories need an auth token. Pass it as a build secret so it never ends up in the final image:
+
+```dockerfile
+# syntax=docker/dockerfile:1.6
+FROM erseco/alpine-php-webserver:latest
+
+USER root
+RUN apk add --no-cache composer
+
+COPY --chown=nobody:nobody ./ /var/www/html
+WORKDIR /var/www/html
+USER nobody
+
+RUN --mount=type=secret,id=composer_auth,target=/home/nobody/.composer/auth.json,uid=65534 \
+    composer install --no-dev --optimize-autoloader --no-interaction --no-progress
+
+USER root
+RUN apk del composer
+USER nobody
+```
+
+Build:
+
+```bash
+DOCKER_BUILDKIT=1 docker build \
+  --secret id=composer_auth,src="$HOME/.composer/auth.json" \
+  -t myapp:latest .
+```
+
+## Why `apk add composer` is safe
+
+Composer is packaged in Alpine's official repositories. Installing it with `apk` is exactly what the upstream Composer image does internally. No `curl | sh`, no GPG ceremony.
+
+## Troubleshooting
+
+### `Composer could not find a composer.json file in /var/www/html`
+
+Cause: Composer ran before `composer.json` was copied in, or in a different directory. Fix the build order ([#40](https://github.com/erseco/alpine-php-webserver/issues/40)):
+
+```dockerfile
+COPY --chown=nobody:nobody ./ /var/www/html
+WORKDIR /var/www/html
+USER nobody
+RUN composer install ...
+```
+
+### `Permission denied` writing to `vendor/`
+
+Cause: Composer is running as `root` but the source files were already copied with `--chown=nobody:nobody`, or vice versa. Pick one approach and stick with it:
+
+- Option A — copy as `nobody`, run Composer as `nobody` (recommended, shown above).
+- Option B — copy as root, run Composer as root, then `chown -R nobody:nobody /var/www/html` at the end.
+
+### `Your requirements could not be resolved` on ARM
+
+Some platform-specific packages fail on `arm/v6` or `arm/v7`. Use `--ignore-platform-reqs` only if you know the missing extension is optional for your use case, or cross-compile from an `amd64` builder.

--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -1,0 +1,179 @@
+# Docker Compose Examples
+
+Drop-in compose stacks for common use cases. Adapt the image tag, passwords and volume paths to your needs.
+
+## Minimal local dev
+
+```yaml
+services:
+  web:
+    image: erseco/alpine-php-webserver
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./php:/var/www/html
+```
+
+## With MariaDB
+
+```yaml
+services:
+  web:
+    image: erseco/alpine-php-webserver
+    restart: unless-stopped
+    environment:
+      date_timezone: Europe/Madrid
+      memory_limit: 256M
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./app:/var/www/html
+    depends_on:
+      - db
+
+  db:
+    image: mariadb:lts
+    restart: unless-stopped
+    environment:
+      MARIADB_ROOT_PASSWORD: rootpw
+      MARIADB_DATABASE: app
+      MARIADB_USER: app
+      MARIADB_PASSWORD: app
+    volumes:
+      - mariadb:/var/lib/mysql
+
+volumes:
+  mariadb:
+```
+
+## With PostgreSQL
+
+```yaml
+services:
+  web:
+    image: erseco/alpine-php-webserver
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./app:/var/www/html
+    depends_on:
+      - db
+
+  db:
+    image: postgres:alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_PASSWORD: app
+      POSTGRES_USER: app
+      POSTGRES_DB: app
+    volumes:
+      - postgres:/var/lib/postgresql
+
+volumes:
+  postgres:
+```
+
+## Behind a reverse proxy (Traefik)
+
+No host port required — the reverse proxy talks to the service over the internal network.
+
+```yaml
+services:
+  web:
+    image: erseco/alpine-php-webserver
+    restart: unless-stopped
+    environment:
+      REAL_IP_HEADER: X-Forwarded-For
+      REAL_IP_RECURSIVE: "on"
+      REAL_IP_FROM: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+    volumes:
+      - ./app:/var/www/html
+    networks:
+      - proxy
+      - default
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=proxy"
+      - "traefik.http.routers.app.rule=Host(`app.example.com`)"
+      - "traefik.http.routers.app.entrypoints=websecure"
+      - "traefik.http.routers.app.tls=true"
+      - "traefik.http.routers.app.tls.certresolver=letsencrypt"
+      - "traefik.http.services.app.loadbalancer.server.port=8080"
+
+networks:
+  proxy:
+    external: true
+```
+
+See [Reverse Proxy & Trusted IPs](reverse-proxy.md) for Nginx, Apache, Caddy and Cloudflare variants.
+
+## Building your own image on top
+
+Use `build:` instead of `image:` when your project needs Composer or custom config baked in.
+
+```yaml
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+```
+
+A matching `Dockerfile`:
+
+```dockerfile
+FROM erseco/alpine-php-webserver:latest
+
+USER root
+RUN apk add --no-cache composer
+USER nobody
+
+COPY --chown=nobody:nobody ./ /var/www/html
+WORKDIR /var/www/html
+
+RUN composer install --no-dev --optimize-autoloader --no-interaction --no-progress
+
+USER root
+RUN apk del composer
+USER nobody
+```
+
+See [Composer & Building](composer.md) for the full recipe.
+
+## Production tuning
+
+```yaml
+services:
+  web:
+    image: erseco/alpine-php-webserver
+    restart: unless-stopped
+    environment:
+      # Serve uploaded files / large POSTs
+      client_max_body_size: 64M
+      post_max_size: 64M
+      upload_max_filesize: 64M
+      memory_limit: 256M
+      max_execution_time: 60
+      fastcgi_read_timeout: 90s
+      fastcgi_send_timeout: 90s
+
+      # OPcache for production
+      opcache_enable: "1"
+      opcache_memory_consumption: "256"
+      opcache_max_accelerated_files: "20000"
+      opcache_validate_timestamps: "0"
+
+      # Locale / timezone
+      date_timezone: UTC
+      intl_default_locale: en_US
+    volumes:
+      - ./app:/var/www/html
+```
+
+!!! warning "OPcache with `opcache_validate_timestamps=0`"
+    Production images that opt into `opcache_validate_timestamps=0` **must** be rebuilt (or the container restarted) on every deploy. Otherwise OPcache will keep serving the previous revision of your PHP files.

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -1,0 +1,71 @@
+# Environment Variables
+
+Full reference for every setting exposed by `erseco/alpine-php-webserver`. Defaults come from the `Dockerfile` and are applied unless you override them.
+
+## Nginx
+
+| Variable                 | Default                  | Purpose |
+|--------------------------|--------------------------|---------|
+| `nginx_root_directory`   | `/var/www/html`          | Document root for the default server block. |
+| `client_max_body_size`   | `2M`                     | Max allowed request body size. Raise for uploads. |
+| `fastcgi_read_timeout`   | `60s`                    | Max time waiting for a response from PHP-FPM. |
+| `fastcgi_send_timeout`   | `60s`                    | Max time transmitting a request to PHP-FPM. |
+| `DISABLE_DEFAULT_LOCATION` | `false`                | Comment out the built-in `location / { ... }` block so you can provide your own via `/etc/nginx/server-conf.d/`. See [#43](https://github.com/erseco/alpine-php-webserver/issues/43). |
+
+## Trusted proxy / real IP
+
+Real IP restoration is **disabled by default**. Configure `REAL_IP_FROM` with a strict allow-list of trusted proxies to enable it.
+
+| Variable             | Default             | Purpose |
+|----------------------|---------------------|---------|
+| `REAL_IP_HEADER`     | `X-Forwarded-For`   | Header Nginx reads as the client IP (`X-Forwarded-For`, `CF-Connecting-IP`, `X-Real-IP`…). |
+| `REAL_IP_RECURSIVE`  | `off`               | `on` = walk the trusted chain recursively. |
+| `REAL_IP_FROM`       | *(empty)*           | Comma-separated list of trusted proxy IPs / CIDRs. **Real IP stays disabled until this is set.** |
+
+See [Reverse Proxy & Trusted IPs](reverse-proxy.md) for concrete recipes.
+
+!!! danger "Never use broad public ranges"
+    `REAL_IP_FROM=0.0.0.0/0` would let any client spoof the configured header. Trust only proxies you control (internal CIDRs, Cloudflare's published ranges, your tunnel connector, etc.).
+
+## PHP runtime
+
+| Variable                 | Default | Purpose |
+|--------------------------|---------|---------|
+| `clear_env`              | `no`    | Keep env vars available to FPM workers. |
+| `allow_url_fopen`        | `On`    | URL-aware `fopen()`. |
+| `allow_url_include`      | `Off`   | URL-aware `include()` / `require()`. Leave off. |
+| `display_errors`         | `Off`   | Render errors in HTTP responses. |
+| `file_uploads`           | `On`    | Enable HTTP uploads. |
+| `max_execution_time`     | `0`     | Max seconds per script. `0` = unlimited. |
+| `max_input_time`         | `-1`    | Max seconds parsing input. `-1` = unlimited. |
+| `max_input_vars`         | `1000`  | Max input vars per request. |
+| `memory_limit`           | `128M`  | Per-request memory ceiling. |
+| `post_max_size`          | `8M`    | Max POST body. Must exceed `upload_max_filesize`. |
+| `upload_max_filesize`    | `2M`    | Max single file upload. |
+| `zlib_output_compression`| `On`    | Transparent output compression. |
+| `date_timezone`          | `UTC`   | PHP `date.timezone`. |
+| `intl_default_locale`    | `en_US` | PHP `intl.default_locale`. |
+
+## OPcache
+
+| Variable                       | Default   | Purpose |
+|--------------------------------|-----------|---------|
+| `opcache_enable`               | `0`       | `1` to enable OPcache. |
+| `opcache_memory_consumption`   | `256`     | Shared memory in MB. |
+| `opcache_max_accelerated_files`| `20000`   | Max cached files. |
+| `opcache_validate_timestamps`  | `0`       | `1` revalidates on every request (dev); `0` never (prod). |
+| `opcache_preload`              | *(empty)* | Preload script path. |
+| `realpath_cache_size`          | `4096K`   | Realpath cache size. |
+| `realpath_cache_ttl`           | `600`     | Realpath cache TTL (seconds). |
+
+See [PHP Configuration](php.md) for usage notes and examples.
+
+## Adding your own variables
+
+Anything not in this table can be injected via:
+
+- `/etc/nginx/conf.d/*.conf` or `/etc/nginx/server-conf.d/*.conf` for Nginx directives
+- `/etc/php84/conf.d/NN-*.ini` for PHP settings
+- A custom image extending this one
+
+See [Extending the Image](extending.md).

--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,0 +1,128 @@
+# Extending the Image
+
+The image is built to be extended. Three patterns cover most needs: **extra daemons**, **startup scripts**, and **running commands as root**.
+
+## Adding extra daemons via `runit`
+
+The runtime is managed by [runit](http://smarden.org/runit/). Each daemon has its own directory under `/etc/service/<name>/` containing an executable `run` script. `runit` keeps them alive and restarts them if they crash.
+
+Example: a memcached sidecar.
+
+Create `memcached.sh`:
+
+```sh
+#!/bin/sh
+exec 2>&1 chpst -u memcache /usr/bin/memcached
+```
+
+Then in your `Dockerfile`:
+
+```dockerfile
+FROM erseco/alpine-php-webserver:latest
+
+USER root
+RUN apk add --no-cache memcached \
+ && mkdir -p /etc/service/memcached
+COPY memcached.sh /etc/service/memcached/run
+RUN chmod +x /etc/service/memcached/run
+
+USER nobody
+```
+
+Important rules:
+
+- The daemon **must run in the foreground**. Don't fork, don't double-fork, don't write a PID file. Use the flag your daemon provides (`-F`, `-f`, `--no-daemonize`).
+- Exec the final command (`exec` in the shell script) so signals propagate correctly.
+- Redirect stderr to stdout (`exec 2>&1 ...`) so both streams reach `docker logs`.
+- Use `chpst -u <user>` to drop privileges if the daemon doesn't do it itself.
+
+!!! info
+    The image's own `nginx` and `php` services are defined exactly the same way under `rootfs/etc/service/nginx/run` and `rootfs/etc/service/php/run`. Read them as templates.
+
+## Startup scripts (`/docker-entrypoint-init.d/`)
+
+Drop executable scripts into `/docker-entrypoint-init.d/` and they run in **lexicographic order** on every container start, right before `runit` takes over. The booting fails if any script exits non-zero.
+
+```sh
+#!/bin/sh
+# logtime.sh
+date > /tmp/boottime.txt
+```
+
+```dockerfile
+COPY logtime.sh /docker-entrypoint-init.d/10-logtime.sh
+RUN chmod +x /docker-entrypoint-init.d/10-logtime.sh
+```
+
+Typical use cases:
+
+- Waiting for a database container (`nc -z db 5432`).
+- Warming caches.
+- Expanding env-var templates into config files not already covered by `envsubst`.
+- Running `composer dump-autoload` after mounting code.
+
+Naming convention: prefix with a two-digit number (`10-`, `20-`, `90-`) to control order.
+
+## Running commands as root
+
+The container runs as `nobody`. Sometimes you need root to install packages, inspect file ownership, or debug something. Use `--user root` on `docker compose exec`:
+
+```bash
+docker compose exec --user root web sh
+```
+
+Examples:
+
+```bash
+# Install a debugging tool
+docker compose exec --user root web sh -c "apk add --no-cache nano curl htop"
+
+# Look at who owns the mounted volume
+docker compose exec --user root web ls -la /var/www/html
+
+# Run a one-off PHP tool as root
+docker compose exec --user root web php -r 'echo PHP_VERSION, PHP_EOL;'
+```
+
+## Adding PHP extensions
+
+Packaged in Alpine? One line:
+
+```dockerfile
+FROM erseco/alpine-php-webserver:latest
+
+USER root
+RUN apk add --no-cache php84-ldap php84-pecl-redis php84-pecl-mongodb
+USER nobody
+```
+
+Not packaged? Build from PECL with `apk add --no-cache $PHPIZE_DEPS` plus `pecl install`. This is heavier and rarely needed.
+
+## Mounting custom config at runtime
+
+You don't always need a new image. For quick tweaks, mount a file directly:
+
+```bash
+# Extra PHP settings
+docker run --rm -p 8080:8080 \
+  -v "$PWD/90-app.ini:/etc/php84/conf.d/90-app.ini:ro" \
+  erseco/alpine-php-webserver
+
+# Extra Nginx server-block rules
+docker run --rm -p 8080:8080 \
+  -v "$PWD/routes.conf:/etc/nginx/server-conf.d/routes.conf:ro" \
+  erseco/alpine-php-webserver
+```
+
+See [Nginx Configuration](nginx.md) and [PHP Configuration](php.md) for the directory conventions.
+
+## Rebuild vs. override: which to pick?
+
+| Situation | What to do |
+|-----------|------------|
+| Tweaking limits (`memory_limit`, `client_max_body_size`, timezone…) | **Environment variables.** No rebuild needed. |
+| Adding one PHP extension | **Build your own image** on top with `apk add`. |
+| Adding one Nginx route | **Mount a file** into `/etc/nginx/server-conf.d/`. |
+| Adding Composer dependencies | **Build your own image**. See [Composer & Building](composer.md). |
+| Running an extra daemon (queue worker, supervisor) | **Build your own image** with an extra `runit` entry. |
+| Debugging production | **`docker compose exec --user root web sh`** — non-persistent. |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,101 @@
+# FAQ
+
+## Which port does the container listen on?
+
+**8080**. Always. The image intentionally avoids privileged ports because it runs as `nobody`. Publish on any host port you like:
+
+```bash
+docker run -p 80:8080 erseco/alpine-php-webserver
+```
+
+## Which user runs inside the container?
+
+`nobody` (UID **65534**). Nginx, PHP-FPM and every startup script run as this user. Bind-mounted host directories must be readable by UID 65534; named volumes get it right automatically.
+
+## Where do I put my code?
+
+`/var/www/html`. Either mount it (dev) or `COPY` it into a derived image (prod).
+
+## How do I install Composer?
+
+You don't install it into this image — you build your own thin image on top with `apk add --no-cache composer`. See [Composer & Building](composer.md) for the recipe.
+
+## How do I add a PHP extension that isn't bundled?
+
+Build a derived image:
+
+```dockerfile
+FROM erseco/alpine-php-webserver:latest
+USER root
+RUN apk add --no-cache php84-ldap php84-pecl-redis
+USER nobody
+```
+
+Extensions available in Alpine: <https://pkgs.alpinelinux.org/packages?name=php84-*&branch=edge>
+
+## What's the connection between Nginx and PHP-FPM?
+
+A Unix socket at `/run/php-fpm.sock`. Adopted in [#16](https://github.com/erseco/alpine-php-webserver/issues/16) — faster and more secure than TCP on localhost.
+
+## Why is there a `/fpm-ping` endpoint?
+
+For the Docker healthcheck. It is locked down to `127.0.0.1` ([#20](https://github.com/erseco/alpine-php-webserver/issues/20)) and returns `pong` when PHP-FPM is responsive. External requests get `403`.
+
+## How do I change PHP settings?
+
+Environment variables. The entrypoint expands `/etc/php84/conf.d/custom.ini.tpl` through `envsubst`. See [PHP Configuration](php.md) and the full [Environment Variables](environment-variables.md) reference.
+
+For settings not exposed as env vars, drop your own `.ini` file into `/etc/php84/conf.d/`:
+
+```bash
+-v "$PWD/90-app.ini:/etc/php84/conf.d/90-app.ini:ro"
+```
+
+## How do I run commands as root?
+
+```bash
+docker compose exec --user root web sh
+```
+
+Used for installing debug tools, inspecting file ownership, or running one-off apk commands. See [Extending the Image](extending.md).
+
+## Can I run additional services (queue worker, supervisor) in the same container?
+
+Yes — add a `runit` entry. Each daemon lives in `/etc/service/<name>/run`. See [Extending the Image](extending.md) for the full pattern, or read the bundled `nginx` and `php` service scripts for working examples.
+
+## Does it support multi-arch?
+
+Yes: `amd64`, `arm64`, `arm/v7`, `arm/v6`, `386`, `ppc64le`, `s390x`. Just pull `erseco/alpine-php-webserver` on any of them.
+
+## What's the difference between `conf.d/` and `server-conf.d/`?
+
+- `/etc/nginx/conf.d/*.conf` is included inside the `http {}` block — use it for global directives and extra `server {}` blocks.
+- `/etc/nginx/server-conf.d/*.conf` is included inside the default `server {}` — use it for custom `location` blocks on the default site.
+
+The distinction was introduced in [#29](https://github.com/erseco/alpine-php-webserver/issues/29).
+
+## How do I turn on OPcache safely?
+
+In production:
+
+```yaml
+environment:
+  opcache_enable: "1"
+  opcache_memory_consumption: "256"
+  opcache_max_accelerated_files: "20000"
+  opcache_validate_timestamps: "0"
+```
+
+And **restart the container on every deploy** — with `validate_timestamps=0`, PHP will not re-read changed files on its own. See [PHP Configuration](php.md).
+
+## How do I get the real client IP?
+
+Set `REAL_IP_FROM` to the list of trusted proxies. Real IP restoration is disabled by default for safety. See [Reverse Proxy & Trusted IPs](reverse-proxy.md).
+
+## What's the image based on? Can I use a newer Alpine version?
+
+Current `main` is on Alpine 3.23, Nginx 1.28, PHP 8.4. Older Alpine versions are available as fixed tags (`3.22`, `3.21`, `3.20`) for backports. Pick the one that matches your stability vs. freshness preference.
+
+## Can I contribute?
+
+Yes — issues and pull requests are welcome. Docs live under `docs/` and are built with [Zensical](https://zensical.org/) via `.github/workflows/docs.yml`.

--- a/docs/healthcheck-logs.md
+++ b/docs/healthcheck-logs.md
@@ -1,0 +1,99 @@
+# Healthcheck & Logs
+
+## Healthcheck
+
+The image defines a Docker healthcheck that hits `/fpm-ping` on the local Nginx:
+
+```dockerfile
+HEALTHCHECK --timeout=10s CMD curl --silent --fail http://127.0.0.1:8080/fpm-ping || exit 1
+```
+
+How it works:
+
+- Nginx has a dedicated `location ~ ^/(fpm-status|fpm-ping)$` block.
+- That block only allows requests from `127.0.0.1` — the rest of the world sees a `403`.
+- The request is forwarded to PHP-FPM via the Unix socket `/run/php-fpm.sock`.
+- PHP-FPM responds with the literal string `pong` when it's healthy.
+
+Why both Nginx and PHP-FPM: healthy Nginx alone is not enough — you want to detect a PHP-FPM worker pool that stopped responding. Hitting `/fpm-ping` proves the FastCGI path works end-to-end.
+
+### Checking healthcheck status
+
+```bash
+docker ps                         # look at the STATUS column
+docker inspect --format='{{json .State.Health}}' <container>
+```
+
+### Using it from outside localhost
+
+It intentionally does not work from outside. Trying `curl http://host:8080/fpm-ping` returns `403 Forbidden` — this is by design ([#20](https://github.com/erseco/alpine-php-webserver/issues/20)). If you need an external probe, expose your own public `/health` endpoint in your app that checks whatever your app considers "healthy":
+
+```php
+// /var/www/html/health.php
+<?php
+http_response_code(200);
+header('Content-Type: text/plain');
+echo "ok\n";
+```
+
+## Logs
+
+All logs go to the container's standard streams so `docker logs` just works.
+
+| Source          | Stream    | Notes |
+|-----------------|-----------|-------|
+| Nginx access    | `stdout`  | Custom `main_timed` format including `$request_time` and `$upstream_response_time`. |
+| Nginx error     | `stderr`  | Level: `notice`. |
+| PHP-FPM         | `stdout` / `stderr` | Worker errors and `php-fpm` messages. |
+| Your PHP app    | `stdout` / `stderr` | Via `error_log = /dev/stderr` in `custom.ini`. |
+| runit services  | `stderr`  | `runit` writes start/stop events and crash loops. |
+
+### Viewing logs
+
+```bash
+docker compose logs -f web                    # follow
+docker compose logs --since 10m web            # recent slice
+docker compose logs web | grep " 500 "         # 500s from the access log
+```
+
+### Custom log format
+
+The format is defined once in `nginx.conf`:
+
+```nginx
+log_format main_timed '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for" '
+                      '$request_time $upstream_response_time $pipe $upstream_cache_status';
+```
+
+That's enough to debug slow responses — `$request_time` is total Nginx time, `$upstream_response_time` is PHP-FPM time. The gap between the two is how long Nginx spent buffering and sending.
+
+### Forwarding to an aggregator
+
+Docker log drivers already do this for you — just configure your daemon or Compose stack:
+
+```yaml
+services:
+  web:
+    image: erseco/alpine-php-webserver
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+```
+
+Or use `syslog`, `fluentd`, `awslogs`, etc. Nothing special required on the image side.
+
+## Access log discipline
+
+Access logs are noisy, but **do not disable them**. They are the first thing you will need when something breaks. If volume is a concern, rotate at the Docker log driver (`json-file` with `max-size`/`max-file`) or ship them to an aggregator with its own retention.
+
+## Tailing with timestamps
+
+`docker logs --timestamps` adds an RFC3339 timestamp per line:
+
+```bash
+docker compose logs -f --timestamps web
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,71 @@
+# Alpine PHP Webserver
+
+A minimal **Nginx + PHP-FPM** Docker image built on [Alpine Linux](https://www.alpinelinux.org/).
+
+[![Docker Pulls](https://img.shields.io/docker/pulls/erseco/alpine-php-webserver.svg)](https://hub.docker.com/r/erseco/alpine-php-webserver/)
+![Docker Image Size](https://img.shields.io/docker/image-size/erseco/alpine-php-webserver)
+![License MIT](https://img.shields.io/badge/license-MIT-blue.svg)
+
+## What is this image?
+
+`erseco/alpine-php-webserver` packages Nginx, PHP-FPM and a handful of common PHP extensions into a **~25 MB** container ready to serve any PHP application. It is designed to be:
+
+- **Small** — Alpine base, single-process-group runtime via [`runit`](http://smarden.org/runit/).
+- **Secure** — Nginx and PHP-FPM run as the unprivileged `nobody` user.
+- **Fast** — `ondemand` FPM process manager; Unix socket between Nginx and PHP; OPcache-ready.
+- **Extensible** — drop extra daemons into `/etc/service/<name>/run`, init scripts into `/docker-entrypoint-init.d/`, Nginx snippets into `/etc/nginx/conf.d/` or `/etc/nginx/server-conf.d/`.
+- **Configurable via env vars** — every meaningful PHP / Nginx setting is templated at startup via `envsubst`.
+
+This image is the **base for [`erseco/alpine-moodle`](https://github.com/erseco/alpine-moodle)** and powers numerous Symfony, Laravel, WordPress and plain PHP deployments.
+
+## Highlights
+
+- Alpine Linux **3.23**, Nginx **1.28**, PHP **8.4** FPM (see the Dockerfile for the actual versions in each tag)
+- Multi-arch: `amd64`, `arm64`, `arm/v7`, `arm/v6`, `386`, `ppc64le`, `s390x`
+- `ondemand` FPM process manager — ~zero idle CPU
+- Unix-socket FastCGI for Nginx ↔ PHP (`/run/php-fpm.sock`)
+- Healthcheck on `/fpm-ping` (localhost-only by design)
+- Logs on `stdout` / `stderr` — just `docker logs -f`
+- Trusted-proxy real IP support (`REAL_IP_FROM`, Cloudflare, Tunnel)
+- `DISABLE_DEFAULT_LOCATION` to fully own the routing layer
+- Follows the **KISS** principle — the runtime is a few small shell scripts you can read in minutes
+
+## Where to start
+
+<div class="grid cards" markdown>
+
+- :material-rocket-launch: **[Quick Start](quick-start.md)** — serve your `./php` directory in under a minute.
+- :material-docker: **[Docker Compose](docker-compose.md)** — local dev stacks, mounting code, building your own image.
+- :material-nginx: **[Nginx Configuration](nginx.md)** — conf.d vs server-conf.d, custom routing, DISABLE_DEFAULT_LOCATION.
+- :material-language-php: **[PHP Configuration](php.md)** — custom.ini, OPcache, timezone, locale.
+- :material-database: **[Environment Variables](environment-variables.md)** — every supported knob.
+- :material-shield-lock: **[Reverse Proxy & Trusted IPs](reverse-proxy.md)** — Traefik, Nginx, Cloudflare, Cloudflare Tunnel.
+- :material-package-variant: **[Composer & Building](composer.md)** — recipes for building production images.
+- :material-puzzle: **[Extending the Image](extending.md)** — runit daemons, init scripts, running as root.
+- :material-heart-pulse: **[Healthcheck & Logs](healthcheck-logs.md)** — what `/fpm-ping` does and where logs go.
+- :material-lightbulb-on: **[Troubleshooting](troubleshooting.md)** — solutions to recurring issues.
+- :material-help-circle: **[FAQ](faq.md)** — quick answers.
+
+</div>
+
+## Minimal example
+
+```bash
+docker run --rm -p 8080:8080 erseco/alpine-php-webserver
+```
+
+- <http://localhost:8080/> — `phpinfo()`
+- <http://localhost:8080/test.html> — static HTML probe
+
+Mount your own code to serve it:
+
+```bash
+docker run --rm -p 8080:8080 -v "$PWD/php:/var/www/html" erseco/alpine-php-webserver
+```
+
+## Project links
+
+- Source code: <https://github.com/erseco/alpine-php-webserver>
+- Docker Hub: <https://hub.docker.com/r/erseco/alpine-php-webserver>
+- GitHub Container Registry: `ghcr.io/erseco/alpine-php-webserver`
+- Issue tracker: <https://github.com/erseco/alpine-php-webserver/issues>

--- a/docs/nginx.md
+++ b/docs/nginx.md
@@ -1,0 +1,135 @@
+# Nginx Configuration
+
+The image ships with a single `nginx.conf` that powers one server block on port **8080**. Every common setting is templated from environment variables at container start through `envsubst`.
+
+## File layout
+
+```
+/etc/nginx/
+├── nginx.conf                 # main file, envsubst'd at startup
+├── conf.d/                    # extra http{} includes (real-ip, global rules)
+└── server-conf.d/             # extra server{} includes (per-route rules)
+```
+
+You have two extension points depending on **where** the snippet needs to go:
+
+| Directory                    | Include location       | Use for |
+|------------------------------|------------------------|---------|
+| `/etc/nginx/conf.d/*.conf`   | inside `http {}`       | upstreams, global directives, additional `server {}` blocks, trusted proxy setup |
+| `/etc/nginx/server-conf.d/*.conf` | inside the default `server {}` | custom `location` blocks, rewrites, auth rules that apply to the main site |
+
+This split was added in response to [#29](https://github.com/erseco/alpine-php-webserver/issues/29) so you don't have to replace the whole `nginx.conf`.
+
+## Mounting snippets
+
+```bash
+docker run --rm -p 8080:8080 \
+  -v "$PWD/my-location.conf:/etc/nginx/server-conf.d/my-location.conf:ro" \
+  erseco/alpine-php-webserver
+```
+
+Compose:
+
+```yaml
+services:
+  web:
+    image: erseco/alpine-php-webserver
+    volumes:
+      - ./app:/var/www/html
+      - ./nginx/my-location.conf:/etc/nginx/server-conf.d/my-location.conf:ro
+```
+
+Example `my-location.conf`:
+
+```nginx
+location /api/ {
+    try_files $uri /api/index.php$is_args$args;
+}
+
+location /static/ {
+    expires 30d;
+    access_log off;
+}
+```
+
+## Overriding the default `location /`
+
+The default server block includes:
+
+```nginx
+location / {
+    try_files $uri $uri/ /index.php$is_args$args;
+}
+```
+
+This works for WordPress, Symfony, Laravel and most front-controller frameworks. If you need something radically different, set `DISABLE_DEFAULT_LOCATION=true` and provide your own `location /` via `/etc/nginx/server-conf.d/` ([#43](https://github.com/erseco/alpine-php-webserver/issues/43)):
+
+```yaml
+services:
+  web:
+    image: erseco/alpine-php-webserver
+    environment:
+      DISABLE_DEFAULT_LOCATION: "true"
+    volumes:
+      - ./app:/var/www/html
+      - ./nginx/custom-root.conf:/etc/nginx/server-conf.d/custom-root.conf:ro
+```
+
+`custom-root.conf`:
+
+```nginx
+location / {
+    return 200 "Custom root handler\n";
+    add_header Content-Type text/plain;
+}
+```
+
+!!! info "How `DISABLE_DEFAULT_LOCATION` works"
+    At startup, the entrypoint comments out the default `location / { ... }` block in `nginx.conf` with `sed`. It does not touch anything else. Your replacement must live in `server-conf.d/`, which is included later in the same server block.
+
+## Clean URLs for Symfony / Laravel
+
+The image already uses a Symfony-friendly `try_files` with `$is_args$args` ([#55](https://github.com/erseco/alpine-php-webserver/issues/55)):
+
+```nginx
+try_files $uri $uri/ /index.php$is_args$args;
+```
+
+No `?q=` parameter pollution. `PATH_INFO` is populated correctly by the PHP `location` block. Nothing extra to configure for Symfony 5/6/7, Laravel, WordPress or plain PHP front-controllers.
+
+## Full file replacement
+
+If you really need a different `nginx.conf`, mount your own over `/etc/nginx/nginx.conf`. Note that it will still be passed through `envsubst`, so `${var}` references must match defined env vars or be escaped.
+
+```bash
+docker run --rm -p 8080:8080 \
+  -v "$PWD/nginx.conf:/etc/nginx/nginx.conf:ro" \
+  erseco/alpine-php-webserver
+```
+
+## Large uploads
+
+Three variables must be raised together:
+
+```yaml
+environment:
+  client_max_body_size: 100M   # Nginx
+  post_max_size:        100M   # PHP
+  upload_max_filesize:  100M   # PHP
+  memory_limit:         256M   # PHP (must exceed post_max_size)
+```
+
+## Long-running scripts
+
+Bump both Nginx and PHP:
+
+```yaml
+environment:
+  fastcgi_read_timeout: 300s
+  fastcgi_send_timeout: 300s
+  max_execution_time:    300
+```
+
+## Gzip is already on
+
+The default config enables gzip for the full Cloudflare-recommended MIME list. There is nothing to turn on.

--- a/docs/php.md
+++ b/docs/php.md
@@ -1,0 +1,113 @@
+# PHP Configuration
+
+PHP settings are templated from a single file — `/etc/php84/conf.d/custom.ini.tpl` — which the entrypoint runs through `envsubst` and writes to `/etc/php84/conf.d/custom.ini`. FPM pool settings (`/etc/php84/php-fpm.d/www.conf`) get the same treatment.
+
+Concretely, **anything you can change via a documented env var is already wired up**. You don't need to mount a custom `php.ini` for the vast majority of settings.
+
+## Core runtime knobs
+
+| Variable               | Default | Purpose |
+|------------------------|---------|---------|
+| `memory_limit`         | `128M`  | Per-request memory ceiling. Raise for Composer, Moosh, large imports. `-1` = unlimited. |
+| `max_execution_time`   | `0`     | Max seconds a script can run. `0` = unlimited. |
+| `max_input_time`       | `-1`    | Max seconds parsing input (POST, GET, uploads). `-1` = unlimited. |
+| `max_input_vars`       | `1000`  | Max POST/GET variables per request. Raise for Moodle-style admin forms. |
+| `post_max_size`        | `8M`    | Max POST body size. Must exceed `upload_max_filesize`. |
+| `upload_max_filesize`  | `2M`    | Max individual file upload size. |
+| `file_uploads`         | `On`    | Enable HTTP uploads. |
+| `display_errors`       | `Off`   | Render errors in responses. Leave off in production. |
+| `allow_url_fopen`      | `On`    | Enable URL-aware fopen wrappers. |
+| `allow_url_include`    | `Off`   | Allow `include()` from URLs. Leave off. |
+| `zlib_output_compression` | `On`  | Transparent output compression. |
+| `clear_env`            | `no`    | Keep env vars available to FPM workers. |
+
+## Locale and timezone
+
+| Variable             | Default   | Purpose |
+|----------------------|-----------|---------|
+| `date_timezone`      | `UTC`     | `date.timezone` in `custom.ini`. Use [PHP timezone identifiers](https://www.php.net/manual/en/timezones.php) — `Europe/Madrid`, `America/New_York`, etc. |
+| `intl_default_locale`| `en_US`   | `intl.default_locale` in `custom.ini`. Used by the `intl` extension and `Locale::getDefault()`. |
+
+```yaml
+environment:
+  date_timezone: Europe/Madrid
+  intl_default_locale: es_ES
+```
+
+## OPcache
+
+OPcache is installed but **disabled by default** so that development mounts reflect changes immediately. Turn it on for production:
+
+```yaml
+environment:
+  opcache_enable: "1"
+  opcache_memory_consumption: "256"
+  opcache_max_accelerated_files: "20000"
+  opcache_validate_timestamps: "0"
+```
+
+| Variable                       | Default   | Purpose |
+|--------------------------------|-----------|---------|
+| `opcache_enable`               | `0`       | `1` = enable OPcache. |
+| `opcache_memory_consumption`   | `256`     | MB reserved for the opcode cache. |
+| `opcache_max_accelerated_files`| `20000`   | Max number of cached files (keep above your script count). |
+| `opcache_validate_timestamps`  | `0`       | `0` = skip mtime checks (prod); `1` = revalidate each request (dev). |
+| `opcache_preload`              | *(empty)* | Path to a [preload script](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.preload). |
+| `realpath_cache_size`          | `4096K`   | Realpath cache size. |
+| `realpath_cache_ttl`           | `600`     | Realpath cache TTL in seconds. |
+
+!!! warning "`opcache_validate_timestamps=0` + live mounts"
+    With `opcache_validate_timestamps=0`, PHP will not re-read files on the fly. In production that is what you want (rebuild the image or restart the container on every deploy). In development, keep it at `1` or OPcache disabled.
+
+### Preloading
+
+```yaml
+environment:
+  opcache_enable: "1"
+  opcache_preload: /var/www/html/config/preload.php
+```
+
+Preload runs at FPM worker startup, so any error in the script will keep workers from booting. Start with a small preload file and grow it.
+
+## Bundled extensions
+
+The image ships with a curated set of PHP 8.4 extensions — enough for most frameworks out of the box:
+
+- Core: `ctype`, `curl`, `dom`, `exif`, `fileinfo`, `iconv`, `intl`, `json`, `mbstring`, `openssl`, `session`, `simplexml`, `soap`, `sodium`, `tokenizer`, `xml`, `xmlreader`, `zip`, `zlib`, `phar`
+- Image: `gd`
+- Databases: `mysqli`, `pdo`, `pdo_mysql`, `pgsql`, `sqlite3`
+- Performance: `opcache`, `pecl-apcu`
+
+Need something else (e.g. `ldap`, `redis`, `imagick`)? Build a thin image on top — see [Composer & Building](composer.md):
+
+```dockerfile
+FROM erseco/alpine-php-webserver:latest
+USER root
+RUN apk add --no-cache php84-ldap php84-pecl-redis
+USER nobody
+```
+
+## Mounting your own `php.ini` snippet
+
+The entrypoint only manages `custom.ini`. You can drop additional `.ini` files into `/etc/php84/conf.d/` and PHP will pick them up:
+
+```bash
+docker run --rm -p 8080:8080 \
+  -v "$PWD/90-my-app.ini:/etc/php84/conf.d/90-my-app.ini:ro" \
+  erseco/alpine-php-webserver
+```
+
+Filename convention: `NN-name.ini` where `NN` controls load order. Use a number ≥ `90` to override the image defaults.
+
+## Verifying the running configuration
+
+```bash
+# Effective settings (merged)
+docker compose exec web php -i | head -60
+
+# Just one setting
+docker compose exec web php -r 'echo ini_get("memory_limit"), PHP_EOL;'
+
+# Check which modules are loaded
+docker compose exec web php -m
+```

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,0 +1,88 @@
+# Quick Start
+
+## Run it
+
+```bash
+docker run --rm -p 8080:8080 erseco/alpine-php-webserver
+```
+
+Open <http://localhost:8080/>. You'll see `phpinfo()` from the bundled `index.php`. The static probe at <http://localhost:8080/test.html> is also served.
+
+Stop with `Ctrl+C`.
+
+## Serve your own code
+
+Bind-mount a local directory into `/var/www/html`:
+
+```bash
+docker run --rm -p 8080:8080 \
+  -v "$PWD/php:/var/www/html" \
+  erseco/alpine-php-webserver
+```
+
+Nginx serves static files directly and hands `*.php` requests to PHP-FPM via the Unix socket at `/run/php-fpm.sock`.
+
+!!! tip "The container runs as `nobody` (UID 65534)"
+    Bind-mounted files must be readable by that user. For write access (sessions, caches, uploads), make the directory writable too:
+
+    ```bash
+    sudo chown -R 65534:65534 ./php
+    ```
+
+    Named Docker volumes get the right ownership automatically.
+
+## With Docker Compose
+
+Save as `docker-compose.yml` next to your code:
+
+```yaml
+services:
+  web:
+    image: erseco/alpine-php-webserver
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./php:/var/www/html
+```
+
+Run it:
+
+```bash
+docker compose up -d
+docker compose logs -f web
+```
+
+See [Docker Compose](docker-compose.md) for more realistic stacks (MariaDB, Redis, reverse proxy).
+
+## What port does it listen on?
+
+**8080** inside the container. The image intentionally does not bind privileged ports because it runs as `nobody`. Map whatever public port you want:
+
+```bash
+docker run --rm -p 80:8080 erseco/alpine-php-webserver   # host 80 → container 8080
+```
+
+## Tweaking limits on the fly
+
+The most common knobs are exposed as environment variables:
+
+```bash
+docker run --rm -p 8080:8080 \
+  -e client_max_body_size=64M \
+  -e upload_max_filesize=64M \
+  -e post_max_size=64M \
+  -e memory_limit=256M \
+  -e date_timezone=Europe/Madrid \
+  -v "$PWD/php:/var/www/html" \
+  erseco/alpine-php-webserver
+```
+
+See [Environment Variables](environment-variables.md) for the full reference.
+
+## Next steps
+
+- Put it behind a [reverse proxy](reverse-proxy.md) for TLS and real client IPs.
+- Build your own image on top with [Composer & Building](composer.md).
+- Add custom Nginx routing with [Nginx Configuration](nginx.md).
+- Enable OPcache for production — see [PHP Configuration](php.md).

--- a/docs/reverse-proxy.md
+++ b/docs/reverse-proxy.md
@@ -1,0 +1,201 @@
+# Reverse Proxy & Trusted IPs
+
+When `alpine-php-webserver` runs behind any HTTPS-terminating proxy you typically need two things:
+
+1. **The PHP app must see the original client IP** — not the proxy's.
+2. **PHP must know the request came in over HTTPS** — so `https://` URLs and secure cookies work.
+
+The image solves both, but both require configuration on the container *and* the proxy.
+
+## Real client IP
+
+Nginx rewrites `$remote_addr` only for proxies you explicitly trust. Set `REAL_IP_FROM` to the list of trusted hops:
+
+```bash
+docker run \
+  -e REAL_IP_HEADER=X-Forwarded-For \
+  -e REAL_IP_RECURSIVE=on \
+  -e REAL_IP_FROM=10.0.0.0/8,172.16.0.0/12,192.168.0.0/16 \
+  erseco/alpine-php-webserver
+```
+
+`REAL_IP_RECURSIVE=on` walks the header chain past every trusted entry, which is almost always what you want.
+
+!!! danger "Never use public CIDR ranges"
+    Do not set `REAL_IP_FROM=0.0.0.0/0` or any public-range shortcut. That would let any client spoof `X-Forwarded-For`. Trust only IPs you control.
+
+## HTTPS awareness
+
+The default Nginx server block already sets:
+
+```nginx
+set $forwarded_scheme "http";
+if ($http_x_forwarded_proto = "https") {
+    set $forwarded_scheme "https";
+}
+...
+fastcgi_param HTTP_X_FORWARDED_PROTO $forwarded_scheme;
+fastcgi_param HTTPS $https if_not_empty;
+```
+
+So as soon as your upstream proxy forwards `X-Forwarded-Proto: https`, PHP will see `$_SERVER['HTTPS']='on'` and frameworks generate HTTPS URLs automatically. No container-side flag needed.
+
+## Traefik
+
+Compose labels, no file changes on the Traefik side:
+
+```yaml
+services:
+  web:
+    image: erseco/alpine-php-webserver
+    restart: unless-stopped
+    environment:
+      REAL_IP_HEADER: X-Forwarded-For
+      REAL_IP_RECURSIVE: "on"
+      REAL_IP_FROM: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+    volumes:
+      - ./app:/var/www/html
+    networks:
+      - proxy
+      - default
+    labels:
+      - "traefik.enable=true"
+      - "traefik.docker.network=proxy"
+      - "traefik.http.routers.app.rule=Host(`app.example.com`)"
+      - "traefik.http.routers.app.entrypoints=websecure"
+      - "traefik.http.routers.app.tls=true"
+      - "traefik.http.routers.app.tls.certresolver=letsencrypt"
+      - "traefik.http.services.app.loadbalancer.server.port=8080"
+
+networks:
+  proxy:
+    external: true
+```
+
+Traefik forwards `X-Forwarded-Proto` automatically. Just match the upstream port — **8080**, not 80.
+
+## Nginx (front proxy)
+
+```nginx
+server {
+    listen 443 ssl http2;
+    server_name app.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/app.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/app.example.com/privkey.pem;
+
+    client_max_body_size 100M;
+
+    location / {
+        proxy_pass         http://web:8080;
+        proxy_http_version 1.1;
+
+        proxy_set_header   Host              $host;
+        proxy_set_header   X-Real-IP         $remote_addr;
+        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header   X-Forwarded-Proto https;
+        proxy_set_header   X-Forwarded-Host  $host;
+
+        proxy_read_timeout 300s;
+    }
+}
+
+server {
+    listen 80;
+    server_name app.example.com;
+    return 301 https://$host$request_uri;
+}
+```
+
+On the container side:
+
+```yaml
+environment:
+  REAL_IP_HEADER: X-Forwarded-For
+  REAL_IP_RECURSIVE: "on"
+  REAL_IP_FROM: 10.0.0.0/8   # the internal network used between nginx and web
+  client_max_body_size: 100M
+```
+
+## Apache (mod_proxy)
+
+```apache
+<VirtualHost *:443>
+    ServerName app.example.com
+
+    SSLEngine on
+    SSLCertificateFile      /etc/letsencrypt/live/app.example.com/fullchain.pem
+    SSLCertificateKeyFile   /etc/letsencrypt/live/app.example.com/privkey.pem
+
+    ProxyPreserveHost On
+    RequestHeader set X-Forwarded-Proto "https"
+    RequestHeader set X-Forwarded-Port  "443"
+
+    ProxyPass        / http://web:8080/
+    ProxyPassReverse / http://web:8080/
+</VirtualHost>
+```
+
+```bash
+a2enmod proxy proxy_http ssl headers rewrite
+```
+
+## Caddy
+
+```caddy
+app.example.com {
+    reverse_proxy web:8080 {
+        header_up Host              {host}
+        header_up X-Forwarded-Proto {scheme}
+        header_up X-Forwarded-For   {remote}
+    }
+}
+```
+
+```yaml
+environment:
+  REAL_IP_HEADER: X-Forwarded-For
+  REAL_IP_RECURSIVE: "on"
+  REAL_IP_FROM: 172.16.0.0/12   # Docker default bridge range
+```
+
+## Cloudflare (proxied DNS)
+
+```bash
+docker run \
+  -e REAL_IP_HEADER=CF-Connecting-IP \
+  -e REAL_IP_RECURSIVE=on \
+  -e REAL_IP_FROM=173.245.48.0/20,103.21.244.0/22,103.22.200.0/22,103.31.4.0/22,141.101.64.0/18,108.162.192.0/18,190.93.240.0/20,188.114.96.0/20,197.234.240.0/22,198.41.128.0/17,162.158.0.0/15,104.16.0.0/13,104.24.0.0/14,172.64.0.0/13,131.0.72.0/22 \
+  erseco/alpine-php-webserver
+```
+
+Cloudflare sets `CF-Connecting-IP` to the real client IP on every proxied request. Use the full, current list of Cloudflare IPs:
+
+- <https://developers.cloudflare.com/fundamentals/concepts/cloudflare-ip-addresses/>
+- <https://www.cloudflare.com/ips-v4/>
+- <https://www.cloudflare.com/ips-v6/>
+
+Keep that list updated (e.g. via a cron that re-deploys the container with refreshed env vars).
+
+## Cloudflare Tunnel / Zero Trust
+
+When `cloudflared` runs as a sidecar or a same-network container, the only hop Nginx sees is the tunnel connector on the internal Docker network:
+
+```yaml
+environment:
+  REAL_IP_HEADER: CF-Connecting-IP
+  REAL_IP_RECURSIVE: "on"
+  REAL_IP_FROM: 172.16.0.0/12   # tighten to the actual subnet cloudflared runs in
+```
+
+Trust only the private CIDR of your tunnel connector, not the entire Cloudflare edge.
+
+## Checklist
+
+Before opening a support issue:
+
+- [ ] The proxy upstream port is `8080` (not 80, not 443).
+- [ ] The proxy forwards `X-Forwarded-Proto`, `X-Forwarded-For`, `Host`.
+- [ ] `REAL_IP_FROM` lists only IPs you control.
+- [ ] The PHP app reads `$_SERVER['HTTPS']` / `$_SERVER['REMOTE_ADDR']`, not raw TCP.
+- [ ] `client_max_body_size` is raised if users upload large files.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,178 @@
+# Troubleshooting
+
+Common failure modes and their fixes, mined from the issue tracker.
+
+## `403 Forbidden` on every request
+
+**Cause**: Nginx can't read the files at `nginx_root_directory`. Either the mount is wrong, or the files are not readable by `nobody` (UID 65534). Related: [#25](https://github.com/erseco/alpine-php-webserver/issues/25).
+
+**Fix**:
+
+```bash
+sudo chown -R 65534:65534 ./app
+sudo find ./app -type d -exec chmod 755 {} \;
+sudo find ./app -type f -exec chmod 644 {} \;
+```
+
+Or use a named Docker volume, which gets the right ownership automatically.
+
+## `phpinfo()` shows instead of my app
+
+**Cause**: You didn't mount your code and the bundled default `index.php` is being served. Related: [#27](https://github.com/erseco/alpine-php-webserver/issues/27).
+
+**Fix**: mount your code into `/var/www/html`:
+
+```bash
+docker run -p 8080:8080 -v "$PWD/app:/var/www/html" erseco/alpine-php-webserver
+```
+
+## Symfony / Laravel URLs have a `?q=` query parameter
+
+**Cause**: You are on an old tag from before [#55](https://github.com/erseco/alpine-php-webserver/issues/55) was fixed. The current `try_files` rule is Symfony-friendly.
+
+**Fix**: `docker pull erseco/alpine-php-webserver` to update. If you really need to stay on an older tag, mount a replacement `server-conf.d/` snippet that overrides the default location block — or set `DISABLE_DEFAULT_LOCATION=true` and provide your own.
+
+## Clean URLs / custom routing don't work
+
+**Cause**: The default `location /` block is interfering with your own routing rules. Related: [#43](https://github.com/erseco/alpine-php-webserver/issues/43).
+
+**Fix**: set `DISABLE_DEFAULT_LOCATION=true` and add your rules via `/etc/nginx/server-conf.d/`:
+
+```yaml
+environment:
+  DISABLE_DEFAULT_LOCATION: "true"
+volumes:
+  - ./nginx/app.conf:/etc/nginx/server-conf.d/app.conf:ro
+```
+
+## Composer build fails with *"could not find a composer.json"*
+
+**Cause**: `composer install` ran before `composer.json` was copied in, or from the wrong working directory. Related: [#40](https://github.com/erseco/alpine-php-webserver/issues/40).
+
+**Fix**: set `WORKDIR` and `COPY` before calling Composer:
+
+```dockerfile
+FROM erseco/alpine-php-webserver:latest
+USER root
+RUN apk add --no-cache composer
+
+COPY --chown=nobody:nobody ./ /var/www/html
+WORKDIR /var/www/html
+USER nobody
+
+RUN composer install --no-dev --optimize-autoloader --no-interaction --no-progress
+```
+
+See [Composer & Building](composer.md).
+
+## Healthcheck always fails from my browser
+
+**Cause**: Expected. The `/fpm-ping` endpoint is localhost-only by design ([#20](https://github.com/erseco/alpine-php-webserver/issues/20)). External probes get a `403`.
+
+**Fix**: use Docker's native healthcheck (already enabled) or add your own public health endpoint in your app:
+
+```php
+<?php
+// public/health.php
+http_response_code(200);
+echo "ok\n";
+```
+
+## Real client IP is always `172.x.y.z`
+
+**Cause**: Nginx is correctly reporting the Docker network gateway, because you haven't told it which proxies to trust. Related: [#72](https://github.com/erseco/alpine-php-webserver/issues/72), [#74](https://github.com/erseco/alpine-php-webserver/issues/74).
+
+**Fix**:
+
+```yaml
+environment:
+  REAL_IP_HEADER: X-Forwarded-For
+  REAL_IP_RECURSIVE: "on"
+  REAL_IP_FROM: 10.0.0.0/8,172.16.0.0/12,192.168.0.0/16
+```
+
+See [Reverse Proxy & Trusted IPs](reverse-proxy.md) for Cloudflare-specific ranges.
+
+## `$_SERVER['HTTPS']` is empty behind HTTPS proxy
+
+**Cause**: The proxy isn't forwarding `X-Forwarded-Proto`, so Nginx doesn't set `HTTPS=on` for FPM.
+
+**Fix**: On the **proxy** side, forward it:
+
+```nginx
+proxy_set_header X-Forwarded-Proto https;
+```
+
+The image already wires `X-Forwarded-Proto` → `$forwarded_scheme` → `HTTPS`.
+
+## Uploads fail silently at ~2 MB
+
+**Cause**: Three limits stack, and two of them are PHP defaults from the image ([see defaults](environment-variables.md)).
+
+**Fix**: raise all three together:
+
+```yaml
+environment:
+  client_max_body_size: 64M     # Nginx
+  post_max_size: 64M            # PHP
+  upload_max_filesize: 64M      # PHP
+  memory_limit: 256M            # PHP, must exceed post_max_size
+```
+
+## Upload hangs for large files
+
+**Cause**: FastCGI timeouts kick in before PHP finishes handling the upload.
+
+**Fix**:
+
+```yaml
+environment:
+  fastcgi_read_timeout: 300s
+  fastcgi_send_timeout: 300s
+  max_execution_time: 300
+  max_input_time: 300
+```
+
+## Permission denied writing to `vendor/` or mounted volume
+
+**Cause**: Files are owned by `root` from an earlier build / bind mount, and `nobody` can't write to them.
+
+**Fix**:
+
+```bash
+# One-off fix on a bind-mounted host directory
+sudo chown -R 65534:65534 ./app
+```
+
+Or inside a custom image:
+
+```dockerfile
+USER root
+RUN chown -R nobody:nobody /var/www/html
+USER nobody
+```
+
+## Container exits immediately with a `runit` error
+
+**Cause**: A service in `/etc/service/<name>/run` crashed on start and `runit` couldn't recover, or a script in `/docker-entrypoint-init.d/` exited non-zero.
+
+**Fix**: run with `docker compose logs -f` to see which script or service failed. The entrypoint prints `*** Failed with return value: N` for init scripts and `sv status <name>` output for services.
+
+## OPcache serves stale code after deploy
+
+**Cause**: `opcache_validate_timestamps=0` is set (correct for production), but the container was not restarted after the deploy.
+
+**Fix**: either restart the container on each deploy (`docker compose up -d --force-recreate web`), or keep `opcache_validate_timestamps=1` during active development.
+
+## Can I run multiple Nginx server blocks?
+
+Yes. Drop additional `server { ... }` declarations into `/etc/nginx/conf.d/*.conf` (not `server-conf.d/` — that one is included *inside* the default server block, not at the `http {}` level). See [Nginx Configuration](nginx.md).
+
+## Still stuck?
+
+Open an issue with:
+
+- The exact image tag (`docker image ls | grep alpine-php-webserver`)
+- Your Compose file or `docker run` command (scrubbed of secrets)
+- `docker compose logs web` output for the failing start
+- Your proxy config if it's a reverse-proxy problem

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,94 @@
+site_name: Alpine PHP Webserver
+site_description: Lightweight Nginx + PHP-FPM Docker image built on Alpine Linux — official documentation.
+site_url: https://erseco.github.io/alpine-php-webserver/
+repo_url: https://github.com/erseco/alpine-php-webserver
+repo_name: erseco/alpine-php-webserver
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  language: en
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - navigation.instant
+    - navigation.tracking
+    - navigation.indexes
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.code.annotate
+    - content.tabs.link
+    - content.action.edit
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  icon:
+    repo: fontawesome/brands/github
+    logo: material/language-php
+
+nav:
+  - Home: index.md
+  - Quick Start: quick-start.md
+  - Docker Compose: docker-compose.md
+  - Nginx Configuration: nginx.md
+  - PHP Configuration: php.md
+  - Environment Variables: environment-variables.md
+  - Reverse Proxy & Trusted IPs: reverse-proxy.md
+  - Composer & Building: composer.md
+  - Extending the Image: extending.md
+  - Healthcheck & Logs: healthcheck-logs.md
+  - Troubleshooting: troubleshooting.md
+  - FAQ: faq.md
+
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.keys
+  - pymdownx.mark
+  - pymdownx.caret
+  - pymdownx.tilde
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/erseco/alpine-php-webserver
+    - icon: fontawesome/brands/docker
+      link: https://hub.docker.com/r/erseco/alpine-php-webserver


### PR DESCRIPTION
Closes #79

## Summary

Publishes a full documentation site under `docs/` built with [Zensical](https://zensical.org/), and deploys it to GitHub Pages on every push to `main`. Same approach as we just shipped in [`erseco/alpine-moodle#140`](https://github.com/erseco/alpine-moodle/pull/140).

The `README.md` is slimmed down to a short overview + quick start + key features, with two sections kept inline because they are the most-referenced in the issue tracker:

- **Environment variables table** (full Nginx + PHP + OPcache reference)
- **Running Commands as Root** (`docker compose exec --user root`)

Everything else — Nginx customisation, reverse proxies, Cloudflare real IP, Composer builds, runit daemons — has been moved into properly-navigable pages.

## What's new

### Docs tree (12 pages)

- `index.md` — landing page with feature overview and navigation cards
- `quick-start.md` — one-liner + mount-your-code + compose
- `docker-compose.md` — minimal, MariaDB, Postgres, reverse-proxy, build-your-own, production-tuning stacks
- `nginx.md` — `conf.d/` vs `server-conf.d/`, `DISABLE_DEFAULT_LOCATION`, Symfony-friendly `try_files`, large uploads, gzip
- `php.md` — `custom.ini` template, OPcache recipe, timezone/locale, bundled extensions, mounting `.ini` files
- `environment-variables.md` — grouped reference for Nginx, real IP, PHP runtime, OPcache
- `reverse-proxy.md` — Traefik, Nginx, Apache, Caddy, Cloudflare (public), Cloudflare Tunnel
- `composer.md` — runtime vs build-time, multi-stage recipe, private repos via BuildKit secrets, common pitfalls
- `extending.md` — runit daemons, `/docker-entrypoint-init.d/`, running as root, adding PHP extensions, rebuild vs override decision table
- `healthcheck-logs.md` — how `/fpm-ping` works, why it's localhost-only, log format, driver tuning
- `troubleshooting.md` — issue-mined failure modes with fixes
- `faq.md` — short answers to recurring questions

### Tooling

- `mkdocs.yml` — Material theme, teal palette, dark/light toggle, instant navigation, search suggestions/highlight, code copy button, annotations, linked content tabs, `pymdownx` extensions (admonitions, details, tabbed, tasklist, highlight, emoji)
- `.github/workflows/docs.yml` — `pip install zensical` on Python 3.12, `zensical build --clean`, uploads a Pages artifact, deploys via `actions/deploy-pages@v4`. Runs only when `docs/**`, `mkdocs.yml` or the workflow change. Uses `pages: write` + `id-token: write` permissions and a Pages concurrency group
- `.gitignore` — adds `/site` and `/.venv`

### README

Refactored to: badges, one-paragraph description, prominent link to the docs site, quick-start snippet, supported tags table, key features list, **Running Commands as Root** (inline), **Environment Variables** reference table (inline), registries, full TOC into the published docs, contributing section.

## Issues mined

The docs explicitly address the following support patterns from the tracker:

- Symfony / Laravel `?q=` routing: #55
- Custom routing via `DISABLE_DEFAULT_LOCATION`: #43
- Unix-socket FastCGI: #16
- Healthcheck endpoint: #20
- `server-conf.d/` include point: #29
- Composer build errors (missing `composer.json`, USER/WORKDIR order, perms): #40
- Trusted proxy real IP / Cloudflare: #72, #74
- Default site / access denied: #25, #27

## Validation

Built locally with `docker run python:3.12-slim` → `pip install zensical` → `zensical build --clean`. All 12 nav pages render, build finishes in 0.18 s.

## Assumptions

- Pages will be published from GitHub Actions. Maintainer needs to set **Settings → Pages → Source: GitHub Actions** once.
- The site URL is `https://erseco.github.io/alpine-php-webserver/`.
- Zensical 0.0.33 on PyPI is the Rust-backed CLI (confirmed via FAQ: `cargo install` is not supported yet because the tool still depends on Python Markdown for Material-for-MkDocs compatibility).

## Test plan

- [ ] Merge and confirm the `docs` workflow runs on `main`
- [ ] Verify Pages deploy succeeds and <https://erseco.github.io/alpine-php-webserver/> loads
- [ ] Check dark/light toggle, search, and code copy work
- [ ] Spot-check every nav link resolves (12 pages)
- [ ] Confirm README renders correctly on GitHub with the docs link and env var table inline