### PR TITLE
fix: link PHP iconv to modern GNU libiconv (main)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ ARG ARCH=
 ARG PHP_SUFFIX=85
 FROM ${ARCH}alpine:3.24 AS php-iconv-builder
 ARG PHP_SUFFIX
+# Fail early on pipe errors in the builder stage (Hadolint DL4006).
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
 # hadolint ignore=DL3018
 RUN apk add --no-cache \
         "php${PHP_SUFFIX}" \
@@ -23,15 +25,19 @@ RUN apk add --no-cache \
         "php${PHP_SUFFIX}-iconv" \
         build-base \
         curl \
-        gnu-libiconv-dev \
- && PHPVER="$(php${PHP_SUFFIX} -r 'echo PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION.".".PHP_RELEASE_VERSION;')" \
+        gnu-libiconv-dev
+# Prefer GNU libiconv headers over musl's incomplete iconv.h.
+RUN rm -f /usr/include/iconv.h \
+ && cp /usr/include/gnu-libiconv/iconv.h /usr/include/iconv.h
+# Fetch PHP sources matching the apk packages; symlink so WORKDIR is stable.
+WORKDIR /tmp
+RUN PHPVER="$(php${PHP_SUFFIX} -r 'echo PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION.".".PHP_RELEASE_VERSION;')" \
  && curl -fsSL "https://www.php.net/distributions/php-${PHPVER}.tar.gz" \
       -o /tmp/php.tar.gz \
- && tar xzf /tmp/php.tar.gz -C /tmp \
- && rm -f /usr/include/iconv.h \
- && cp /usr/include/gnu-libiconv/iconv.h /usr/include/iconv.h \
- && cd "/tmp/php-${PHPVER}/ext/iconv" \
- && "phpize${PHP_SUFFIX}" \
+ && tar xzf /tmp/php.tar.gz \
+ && ln -sfn "/tmp/php-${PHPVER}/ext/iconv" /tmp/iconv-src
+WORKDIR /tmp/iconv-src
+RUN "phpize${PHP_SUFFIX}" \
  && ./configure \
       --with-php-config="/usr/bin/php-config${PHP_SUFFIX}" \
       --with-iconv=/usr \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,44 @@
+# Rebuild PHP iconv against Alpine's modern GNU libiconv (//TRANSLIT//IGNORE).
+#
+# Context:
+# - Alpine packages PHP against musl iconv, which does not implement the GNU
+#   //TRANSLIT and //IGNORE suffixes. Apps such as Moodle rely on them
+#   (core_text::specialtoascii / role short names):
+#   https://github.com/erseco/alpine-moodle/issues/26
+# - Alpine will not rebuild php*-iconv against gnu-libiconv:
+#   https://gitlab.alpinelinux.org/alpine/aports/-/issues/15114
+# - Official docker-library PHP Alpine images compile PHP with gnu-libiconv.
+#   We keep apk PHP packages and only rebuild the shared iconv extension.
+#
+# Result: iconv.so is linked to Alpine's current gnu-libiconv (1.17/1.18).
+# No process-wide preload and no ancient libiconv pin.
+ARG ARCH=
+ARG PHP_SUFFIX=85
+FROM ${ARCH}alpine:3.24 AS php-iconv-builder
+ARG PHP_SUFFIX
+# hadolint ignore=DL3018
+RUN apk add --no-cache \
+        "php${PHP_SUFFIX}" \
+        "php${PHP_SUFFIX}-dev" \
+        "php${PHP_SUFFIX}-iconv" \
+        build-base \
+        curl \
+        gnu-libiconv-dev \
+ && PHPVER="$(php${PHP_SUFFIX} -r 'echo PHP_MAJOR_VERSION.".".PHP_MINOR_VERSION.".".PHP_RELEASE_VERSION;')" \
+ && curl -fsSL "https://www.php.net/distributions/php-${PHPVER}.tar.gz" \
+      -o /tmp/php.tar.gz \
+ && tar xzf /tmp/php.tar.gz -C /tmp \
+ && rm -f /usr/include/iconv.h \
+ && cp /usr/include/gnu-libiconv/iconv.h /usr/include/iconv.h \
+ && cd "/tmp/php-${PHPVER}/ext/iconv" \
+ && "phpize${PHP_SUFFIX}" \
+ && ./configure \
+      --with-php-config="/usr/bin/php-config${PHP_SUFFIX}" \
+      --with-iconv=/usr \
+      LIBS="-liconv" \
+ && make -j"$(nproc)" \
+ && install -D -m755 modules/iconv.so /out/iconv.so
+
 ARG ARCH=
 FROM ${ARCH}alpine:3.24
 
@@ -66,6 +107,20 @@ RUN apk --no-cache add \
 # Make sure files/folders needed by the processes are accessable when they run under the nobody user
     && mkdir -p /run /var/lib/nginx /var/www/html /var/log/nginx \
     && chown -R nobody:nobody /run /var/lib/nginx /var/www/html /var/log/nginx
+
+
+# Replace stock musl-linked php iconv with the GNU libiconv build from the builder stage.
+# Runtime needs libiconv.so.2 (gnu-libiconv / gnu-libiconv-libs).
+# hadolint ignore=DL3018
+RUN apk add --no-cache gnu-libiconv
+COPY --from=php-iconv-builder /out/iconv.so /usr/lib/php85/modules/iconv.so
+# Fail the build if transliteration is still unavailable.
+RUN out="$(php85 -r 'echo iconv("UTF-8", "ASCII//TRANSLIT//IGNORE", "café");')" \
+ && echo "iconv TRANSLIT check: $out" \
+ && [ -n "$out" ]
+
+
+
 
 # Add configuration files
 COPY --chown=nobody rootfs/ /


### PR DESCRIPTION
## Summary

Alpine packages PHP against **musl iconv**, which does not implement the GNU `//TRANSLIT` / `//IGNORE` suffixes. That breaks applications such as Moodle (`core_text::specialtoascii`, role short names — see [erseco/alpine-moodle#26](https://github.com/erseco/alpine-moodle/issues/26)). Alpine is not going to rebuild `php*-iconv` against gnu-libiconv ([aports#15114](https://gitlab.alpinelinux.org/alpine/aports/-/issues/15114)).

### Approach (modern, no ancient pin)

Same idea as the official `docker-library/php` Alpine images, but scoped to a single extension:

1. Multi-stage build: install Alpine’s **current** `gnu-libiconv-dev` (1.17 on 3.20–3.22, **1.18** on 3.23+).
2. Rebuild only the shared `iconv` PHP extension against that library (`--with-iconv=/usr`, `LIBS="-liconv"`).
3. Copy the new `iconv.so` into the final image and install runtime `gnu-libiconv`.
4. Build-time smoke test: `iconv(..., "ASCII//TRANSLIT//IGNORE", "café")` must return a non-empty string.

### What this is *not*

- **Not** libiconv 1.15 + `LD_PRELOAD` / `preloadable_libiconv.so` (that path is dead: preload was removed upstream in 1.16+, and pinning 1.15 is what we want to avoid).
- **Not** a full PHP rebuild from source — only `ext/iconv`.

### Hadolint notes

`# hadolint ignore=DL3018` is used on the builder/runtime `apk add` lines for build tooling and `gnu-libiconv`, consistent with the rest of this Dockerfile (unpinned Alpine packages). Remaining style nits (`cd` in the builder `RUN`) are intentional so the PHP version directory can be resolved at build time.

### Scope

- **Dockerfile only**
- Same change on `main`, `3.23.x`, `3.22.x`, `3.21.x`, `3.20.x`

## Test plan

- [x] `docker build` prints `iconv TRANSLIT check: caf'e`
- [x] Runtime: `iconv implementation => libiconv`, library **1.18** (main / 3.23+) or **1.17** (3.20–3.22)
- [ ] CI `buildx` green on this PR
- [ ] After merge: `alpine-moodle` can drop its v3.13 `gnu-libiconv=1.15-r3` pin